### PR TITLE
Redesign Router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.10"

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,23 +1,13 @@
-Cosmos.Router = function(options) {
-  // The Router defaults are dynamic values they must be read whenever an
-  // instance is created, thus they are not embedded in the Class prototype
-  this.options = _.extend({
-    props: Cosmos.url.getParams(),
-    container: document.body
-  }, options);
+Cosmos.Router = function(defaultProps, container) {
+  this._defaultProps = defaultProps || {};
+  this._container = container || document.body;
 
-  // defaultsProps is not applied when props are missing, but when they are
-  // empty (regardless if they come from options or the default Rotuer props)
-  if (_.isEmpty(this.options.props) && this.options.defaultProps) {
-    this.options.props = this.options.defaultProps;
-  }
-
-  this.container = this.options.container;
-  this._onPopState = this._onPopState.bind(this);
+  this.onPopState = this.onPopState.bind(this);
   this._bindPopStateEvent();
 
-  // The initial render is done when the Router is instantiated
-  this._load(this.options.props, window.location.href);
+  // The initial render is done instantly when the Router instance is created
+  this._load(this._attachDefaultsToProps(Cosmos.url.getParams()),
+             window.location.href);
 };
 
 _.extend(Cosmos.Router, {
@@ -33,38 +23,29 @@ _.extend(Cosmos.Router, {
         return;
       }
 
-      // The history entry for the previous Component is updated with its
+      // The history entry for the previous component is updated with its
       // lastest props and state, so that we resume it its exact form when/if
       // going back
       if (this.rootComponent) {
-        this._replaceHistoryState(
-          this.rootComponent.generateSnapshot(),
-          this._currentHref);
+        this._replaceHistoryState(this.rootComponent.generateSnapshot(),
+                                  this._currentHref);
       }
 
       var queryString = href.split('?').pop(),
           props = Cosmos.serialize.getPropsFromQueryString(queryString);
-      // Calling pushState doesn't trigger the onpopstate event, so push state
-      // events and programatic Router calls are individually handled
-      // https://developer.mozilla.org/en-US/docs/Web/API/window.onpopstate
-      this._load(props, href);
-      this._pushHistoryState(props, href);
+
+      // The callback has the component as the context
+      var _this = this;
+      this._load(this._attachDefaultsToProps(props), href, function() {
+        // Calling pushState programatically doesn't trigger the onpopstate
+        // event, only a browser page change does. Otherwise this would've
+        // triggered an infinite loop.
+        // https://developer.mozilla.org/en-US/docs/Web/API/window.onpopstate
+        _this._pushHistoryState(this.generateSnapshot(), href);
+      });
     },
 
-    _load: function(props, href) {
-      this.rootComponent = Cosmos.render(props, this.container);
-      this._currentHref = href;
-    },
-
-    _bindPopStateEvent: function() {
-      window.addEventListener('popstate', this._onPopState);
-    },
-
-    _unbindPopStateEvent: function() {
-      window.removeEventListener('popstate', this._onPopState);
-    },
-
-    _onPopState: function(e) {
+    onPopState: function(e) {
       // Chrome & Safari trigger an empty popState event initially, while
       // Firefox doesn't, we choose to ignore that event altogether
       if (!e.state) {
@@ -73,12 +54,29 @@ _.extend(Cosmos.Router, {
       this._load(e.state, window.location.href);
     },
 
+    _load: function(props, href, callback) {
+      this.rootComponent = Cosmos.render(props, this._container, callback);
+      this._currentHref = href;
+    },
+
+    _bindPopStateEvent: function() {
+      window.addEventListener('popstate', this.onPopState);
+    },
+
+    _unbindPopStateEvent: function() {
+      window.removeEventListener('popstate', this.onPopState);
+    },
+
     _replaceHistoryState: function(props, url) {
       window.history.replaceState(props, '', url);
     },
 
     _pushHistoryState: function(state, url) {
       window.history.pushState(state, '', url);
+    },
+
+    _attachDefaultsToProps: function(props) {
+      return _.extend({}, this._defaultProps, props);
     }
   }
 });

--- a/lib/router.js
+++ b/lib/router.js
@@ -6,8 +6,7 @@ Cosmos.Router = function(defaultProps, container) {
   this._bindPopStateEvent();
 
   // The initial render is done instantly when the Router instance is created
-  this._load(this._attachDefaultsToProps(Cosmos.url.getParams()),
-             window.location.href);
+  this._load(Cosmos.url.getParams(), window.location.href);
 };
 
 _.extend(Cosmos.Router, {
@@ -27,7 +26,8 @@ _.extend(Cosmos.Router, {
       // lastest props and state, so that we resume it its exact form when/if
       // going back
       if (this.rootComponent) {
-        this._replaceHistoryState(this.rootComponent.generateSnapshot(),
+        var snapshot = this.rootComponent.generateSnapshot();
+        this._replaceHistoryState(this._excludeDefaultProps(snapshot),
                                   this._currentHref);
       }
 
@@ -36,12 +36,13 @@ _.extend(Cosmos.Router, {
 
       // The callback has the component as the context
       var _this = this;
-      this._load(this._attachDefaultsToProps(props), href, function() {
+      this._load(props, href, function() {
         // Calling pushState programatically doesn't trigger the onpopstate
         // event, only a browser page change does. Otherwise this would've
         // triggered an infinite loop.
         // https://developer.mozilla.org/en-US/docs/Web/API/window.onpopstate
-        _this._pushHistoryState(this.generateSnapshot(), href);
+        var snapshot = this.generateSnapshot();
+        _this._pushHistoryState(_this._excludeDefaultProps(snapshot), href);
       });
     },
 
@@ -55,7 +56,7 @@ _.extend(Cosmos.Router, {
     },
 
     _load: function(newProps, href, callback) {
-      var props = _.extend({}, newProps, {
+      var props = _.extend({}, this._defaultProps, newProps, {
         // Always send the components a reference to the router. This makes it
         // possible for a component to change the page through the router and
         // not have to rely on any sort of globals
@@ -73,16 +74,27 @@ _.extend(Cosmos.Router, {
       window.removeEventListener('popstate', this.onPopState);
     },
 
-    _replaceHistoryState: function(props, url) {
-      window.history.replaceState(props, '', url);
+    _replaceHistoryState: function(state, url) {
+      window.history.replaceState(state, '', url);
     },
 
     _pushHistoryState: function(state, url) {
       window.history.pushState(state, '', url);
     },
 
-    _attachDefaultsToProps: function(props) {
-      return _.extend({}, this._defaultProps, props);
+    _excludeDefaultProps: function(props) {
+      var newProps = {},
+          value;
+
+      for (var key in props) {
+        value = props[key];
+
+        if (value !== this._defaultProps[key]) {
+          newProps[key] = value;
+        }
+      }
+
+      return newProps;
     }
   }
 });

--- a/lib/router.js
+++ b/lib/router.js
@@ -87,6 +87,12 @@ _.extend(Cosmos.Router, {
           value;
 
       for (var key in props) {
+        // Ignore the Router reference because it gets attached automatically
+        // when sending new props to a component 
+        if (key === 'router') {
+          continue;
+        }
+
         value = props[key];
 
         if (value !== this._defaultProps[key]) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -54,7 +54,13 @@ _.extend(Cosmos.Router, {
       this._load(e.state, window.location.href);
     },
 
-    _load: function(props, href, callback) {
+    _load: function(newProps, href, callback) {
+      var props = _.extend({}, newProps, {
+        // Always send the components a reference to the router. This makes it
+        // possible for a component to change the page through the router and
+        // not have to rely on any sort of globals
+        router: this
+      });
       this.rootComponent = Cosmos.render(props, this._container, callback);
       this._currentHref = href;
     },

--- a/lib/router.js
+++ b/lib/router.js
@@ -5,28 +5,34 @@ Cosmos.Router = function(options) {
     props: Cosmos.url.getParams(),
     container: document.body
   }, options);
+
   // defaultsProps is not applied when props are missing, but when they are
   // empty (regardless if they come from options or the default Rotuer props)
   if (_.isEmpty(this.options.props) && this.options.defaultProps) {
     this.options.props = this.options.defaultProps;
   }
+
   this.container = this.options.container;
   this._onPopState = this._onPopState.bind(this);
   this._bindPopStateEvent();
+
   // The initial render is done when the Router is instantiated
   this._load(this.options.props, window.location.href);
 };
+
 _.extend(Cosmos.Router, {
   prototype: {
     stop: function() {
       this._unbindPopStateEvent();
     },
+
     goTo: function(href) {
       // Old-school refreshes are made when pushState isn't supported
       if (!Cosmos.url.isPushStateSupported()) {
         window.location = href;
         return;
       }
+
       // The history entry for the previous Component is updated with its
       // lastest props and state, so that we resume it its exact form when/if
       // going back
@@ -35,6 +41,7 @@ _.extend(Cosmos.Router, {
           this.rootComponent.generateSnapshot(),
           this._currentHref);
       }
+
       var queryString = href.split('?').pop(),
           props = Cosmos.serialize.getPropsFromQueryString(queryString);
       // Calling pushState doesn't trigger the onpopstate event, so push state
@@ -43,16 +50,20 @@ _.extend(Cosmos.Router, {
       this._load(props, href);
       this._pushHistoryState(props, href);
     },
+
     _load: function(props, href) {
       this.rootComponent = Cosmos.render(props, this.container);
       this._currentHref = href;
     },
+
     _bindPopStateEvent: function() {
       window.addEventListener('popstate', this._onPopState);
     },
+
     _unbindPopStateEvent: function() {
       window.removeEventListener('popstate', this._onPopState);
     },
+
     _onPopState: function(e) {
       // Chrome & Safari trigger an empty popState event initially, while
       // Firefox doesn't, we choose to ignore that event altogether
@@ -61,9 +72,11 @@ _.extend(Cosmos.Router, {
       }
       this._load(e.state, window.location.href);
     },
+
     _replaceHistoryState: function(props, url) {
       window.history.replaceState(props, '', url);
     },
+
     _pushHistoryState: function(state, url) {
       window.history.pushState(state, '', url);
     }

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,31 +1,41 @@
 Cosmos.serialize = {
   getPropsFromQueryString: function(queryString) {
     var props = {};
-    if (queryString.length) {
-      var pairs = queryString.split('&'),
-          parts,
-          key,
-          value;
-      for (var i = 0; i < pairs.length; i++) {
-        parts = pairs[i].split('=');
-        key = parts[0];
-        value = decodeURIComponent(parts[1]);
-        try {
-          value = JSON.parse(value);
-        } catch(e) {
-          // If the prop was a simple type and not a stringified JSON it will
-          // keep its original value
-        }
-        props[key] = value;
-      }
+
+    if (!queryString.length) {
+      return props;
     }
+
+    var pairs = queryString.split('&'),
+        parts,
+        key,
+        value;
+
+    for (var i = 0; i < pairs.length; i++) {
+      parts = pairs[i].split('=');
+      key = parts[0];
+      value = decodeURIComponent(parts[1]);
+
+      try {
+        value = JSON.parse(value);
+      } catch(e) {
+        // If the prop was a simple type and not a stringified JSON it will
+        // keep its original value
+      }
+
+      props[key] = value;
+    }
+
     return props;
   },
+
   getQueryStringFromProps: function(props) {
     var parts = [],
         value;
+
     for (var key in props) {
       value = props[key];
+
       // Objects can be embedded in a query string as well
       if (typeof value == 'object') {
         try {
@@ -35,8 +45,10 @@ Cosmos.serialize = {
           continue;
         }
       }
+
       parts.push(key + '=' + encodeURIComponent(value));
     }
+
     return parts.join('&');
   }
 };

--- a/lib/url.js
+++ b/lib/url.js
@@ -3,6 +3,7 @@ Cosmos.url = {
     return Cosmos.serialize.getPropsFromQueryString(
       window.location.search.substr(1));
   },
+  
   isPushStateSupported: function() {
     return !!window.history.pushState;
   }

--- a/mixins/url.js
+++ b/mixins/url.js
@@ -13,6 +13,7 @@ Cosmos.mixins.Url = {
      */
     return '?' + Cosmos.serialize.getQueryStringFromProps(props);
   },
+  
   routeLink: function(e) {
     /**
      * Any <a> tag can have this method bound to its onClick event to have

--- a/mixins/url.js
+++ b/mixins/url.js
@@ -13,15 +13,15 @@ Cosmos.mixins.Url = {
      */
     return '?' + Cosmos.serialize.getQueryStringFromProps(props);
   },
-  
-  routeLink: function(e) {
+
+  routeLink: function(event) {
     /**
      * Any <a> tag can have this method bound to its onClick event to have
      * their corresponding href location picked up by the built-in Router
      * implementation, which uses pushState to switch between Components
      * instead of reloading pages.
      */
-    e.preventDefault();
-    App.router.goTo(e.currentTarget.getAttribute('href'));
+    event.preventDefault();
+    this.props.router.goTo(event.currentTarget.getAttribute('href'));
   }
 };

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -40,18 +40,6 @@ describe("Cosmos.Router", function() {
         expect(router.options.props).toEqual(Cosmos.url.getParams());
       });
 
-      it("should use default props when props are empty", function() {
-        spyOn(Cosmos.url, 'getParams').and.returnValue({});
-
-        var router = new Cosmos.Router({defaultProps: {
-          component: 'DefaultComponent'
-        }});
-
-        expect(router.options.props).toEqual({
-          component: 'DefaultComponent'
-        });
-      });
-
       it("shouldn't use default props when props aren't empty", function() {
         var router = new Cosmos.Router({defaultProps: {
           component: 'DefaultComponent'

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -171,7 +171,6 @@ describe("Cosmos.Router", function() {
         // This won't be called because Cosmos.render is mocked
       };
 
-      // Simulate some state addition in the component
       spyOn(componentInstance, 'generateSnapshot').and.callFake(function() {
         return {
           component: 'List',

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -147,6 +147,7 @@ describe("Cosmos.Router", function() {
     // Before routing to a new Component configuration, the previous one
     // shouldn't been updated with our changes
     router.goTo('?component=User&dataUrl=user.json');
+    
     expect(router._replaceHistoryState.calls.count()).toEqual(1);
     expect(router._replaceHistoryState.calls.mostRecent().args[0]).toEqual({
       component: 'List',

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -144,7 +144,7 @@ describe("Cosmos.Router", function() {
       router.goTo('?component=List&dataUrl=users.json');
 
       // Simulate React.render callback call
-      componentCallback.call(componentInstance, 'testx');
+      componentCallback.call(componentInstance);
 
       // The snapshot should've been extracted from the component
       expect(componentInstance.generateSnapshot).toHaveBeenCalled();

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -8,7 +8,12 @@ describe("Cosmos.Router", function() {
   // in test cases as well.
   var React,
       utils,
-      Cosmos;
+      Cosmos,
+      propsFromQueryString,
+      ComponentClass,
+      componentElement,
+      componentInstance,
+      componentCallback;
 
   beforeEach(function() {
     global.window = jsdom.jsdom().createWindow('<html><body></body></html>');
@@ -19,116 +24,183 @@ describe("Cosmos.Router", function() {
     utils = React.addons.TestUtils;
     Cosmos = require('../build/cosmos.js');
 
-    // Ignore external methods
+    // Ignore native APIs
     spyOn(Cosmos.Router.prototype, '_bindPopStateEvent');
     spyOn(Cosmos.Router.prototype, '_replaceHistoryState');
     spyOn(Cosmos.Router.prototype, '_pushHistoryState');
-    spyOn(Cosmos.url, 'isPushStateSupported').and.returnValue(true);
 
     // The Cosmos.url lib is already tested in isolation
-    spyOn(Cosmos.url, 'getParams').and.returnValue({
+    propsFromQueryString = {
       component: 'List',
       data: 'users.json'
+    };
+    spyOn(Cosmos.url, 'getParams').and.returnValue(propsFromQueryString);
+    spyOn(Cosmos.url, 'isPushStateSupported').and.returnValue(true);
+
+    // We just want a valid instance to work with, the Router props won't be
+    // taken into consideration
+    spyOn(Cosmos, 'render').and.callFake(function(props, container, callback) {
+      componentCallback = callback;
+      return componentInstance;
+    });
+
+    // Clean up previous component setups
+    ComponentClass = null;
+    componentElement = null;
+    componentInstance = null;
+  });
+
+  it("should use props from URL query string", function() {
+    var router = new Cosmos.Router();
+
+    expect(Cosmos.render.calls.mostRecent().args[0])
+          .toEqual(propsFromQueryString);
+  });
+
+  it("should extend default props", function() {
+    var router = new Cosmos.Router({
+      component: 'DefaultComponent',
+      defaultProp: true
+    });
+
+    expect(Cosmos.render.calls.mostRecent().args[0]).toEqual({
+      component: 'List',
+      data: 'users.json',
+      // The props for the url didn't override this prop
+      defaultProp: true
     });
   });
 
-  describe("new instance", function() {
+  it("should default to document.body as container", function() {
+    var router = new Cosmos.Router();
 
-      beforeEach(function() {
-        spyOn(Cosmos, 'render');
-      });
-
-      it("should default to URL query string", function() {
-        var router = new Cosmos.Router();
-
-        expect(router.options.props).toEqual(Cosmos.url.getParams());
-      });
-
-      it("shouldn't use default props when props aren't empty", function() {
-        var router = new Cosmos.Router({defaultProps: {
-          component: 'DefaultComponent'
-        }});
-
-        expect(router.options.props).toEqual(Cosmos.url.getParams());
-      });
-
-      it("should default to document.body as container", function() {
-        var router = new Cosmos.Router();
-
-        expect(router.options.container).toBe(document.body);
-      });
-
-      it("should save a reference to the DOM container", function() {
-        var container = React.DOM.span();
-            router = new Cosmos.Router({container: '<span>'});
-
-        expect(router.container).toEqual('<span>');
-      });
+    expect(Cosmos.render.calls.mostRecent().args[1]).toBe(document.body);
   });
 
-  describe("should render new Components", function() {
+  it("should use props from .goTo method", function() {
+    var router = new Cosmos.Router();
+    router.goTo('?component=List&dataUrl=users.json');
 
-    beforeEach(function() {
-      spyOn(Cosmos, 'render');
+    expect(Cosmos.render.calls.count()).toEqual(2);
+    expect(Cosmos.render.calls.mostRecent().args[0]).toEqual({
+      component: 'List',
+      dataUrl: 'users.json'
     });
+  });
 
-    it("with constructor props and container", function() {
-      var router = new Cosmos.Router({
-        props: {component: 'List', dataUrl: 'users.json'},
-        container: '<span>'
-      });
-
-      expect(Cosmos.render.calls.count()).toEqual(1);
-      expect(Cosmos.render.calls.mostRecent().args[0]).toEqual({
-        component: 'List', dataUrl: 'users.json'
-      });
-      expect(Cosmos.render.calls.mostRecent().args[1]).toEqual('<span>');
+  it("should extend default props when using .goTo method", function() {
+    var router = new Cosmos.Router({
+      component: 'DefaultComponent',
+      defaultProp: true
     });
+    router.goTo('?component=List&dataUrl=users.json');
 
-    it("with props extracted from query string on .goTo", function() {
-      var router = new Cosmos.Router({});
-      router.goTo('?component=List&dataUrl=users.json');
+    expect(Cosmos.render.calls.count()).toEqual(2);
+    expect(Cosmos.render.calls.mostRecent().args[0]).toEqual({
+      component: 'List',
+      dataUrl: 'users.json',
+      // The props for the url didn't override this prop
+      defaultProp: true
+    });
+  });
 
-      expect(Cosmos.render.calls.count()).toEqual(2);
-      expect(Cosmos.render.calls.mostRecent().args[0]).toEqual({
+  it("should push component snapshot to state when using .goTo method",
+     function() {
+    ComponentClass = React.createClass({
+      mixins: [Cosmos.mixins.PersistState],
+      render: function() {
+        return React.DOM.span();
+      }
+    });
+    componentElement = React.createElement(ComponentClass, {
+      component: 'List',
+      dataUrl: 'users.json'
+    });
+    componentInstance = utils.renderIntoDocument(componentElement);
+
+    // Simulate some state addition in the component
+    spyOn(componentInstance, 'generateSnapshot').and.callFake(function() {
+      return {
         component: 'List',
-        dataUrl: 'users.json'
-      });
-    });
-
-    it("with props from event state on PopState event", function() {
-      var router = new Cosmos.Router({});
-      router._onPopState({
+        dataUrl: 'users.json',
         state: {
-          component: 'List',
-          dataUrl: 'users.json'
+          haveISeenThings: 'yes'
         }
-      });
+      };
+    });
 
-      expect(Cosmos.render.calls.count()).toEqual(2);
-      expect(Cosmos.render.calls.mostRecent().args[0]).toEqual({
+    var router = new Cosmos.Router();
+    router.goTo('?component=List&dataUrl=users.json');
+
+    // Simulate React.render callback call
+    componentCallback.call(componentInstance, 'testx');
+
+    // The snapshot shouldn't been extracted from the component two times
+    // 1. For previous component
+    // 2. For just loaded component
+    expect(componentInstance.generateSnapshot.calls.count()).toEqual(2);
+
+    // It's a bit difficult to mock the native functions so we mocked the
+    // private methods that wrap those calls
+    expect(router._pushHistoryState.calls.count()).toEqual(1);
+    expect(router._pushHistoryState.calls.mostRecent().args[0]).toEqual({
+      component: 'List',
+      dataUrl: 'users.json',
+      state: {
+        haveISeenThings: 'yes'
+      }
+    });
+  });
+
+  it("should use props from PopState event state", function() {
+    var router = new Cosmos.Router();
+    router.onPopState({
+      state: {
         component: 'List',
         dataUrl: 'users.json'
-      });
+      }
+    });
+
+    expect(Cosmos.render.calls.count()).toEqual(2);
+    expect(Cosmos.render.calls.mostRecent().args[0]).toEqual({
+      component: 'List',
+      dataUrl: 'users.json'
+    });
+  });
+
+  it("shouldn't extend default props when using PopState event", function() {
+    var router = new Cosmos.Router({
+      component: 'DefaultComponent',
+      defaultProp: true
+    });
+    router.onPopState({
+      state: {
+        component: 'List',
+        dataUrl: 'users.json'
+      }
+    });
+
+    expect(Cosmos.render.calls.count()).toEqual(2);
+    expect(Cosmos.render.calls.mostRecent().args[0]).toEqual({
+      component: 'List',
+      dataUrl: 'users.json'
     });
   });
 
   it("should cache latest snapshot of previous Component", function() {
-    var ComponentClass = React.createClass({
-          mixins: [Cosmos.mixins.PersistState],
-          render: function() {
-            return React.DOM.span();
-          }
-        }),
-        props = {component: 'List', dataUrl: 'users.json'},
-        componentElement = React.createElement(ComponentClass, props)
-        componentInstance = utils.renderIntoDocument(componentElement);
-
-    // We just want a valid instance to work with, the Router props won't be
-    // taken into consideration
-    spyOn(Cosmos, 'render').and.callFake(function(props) {
-      return componentInstance;
+    /* Note: This is not a pure unit test, it depends on the internal logic
+       of React components */
+    ComponentClass = React.createClass({
+      mixins: [Cosmos.mixins.PersistState],
+      render: function() {
+        return React.DOM.span();
+      }
     });
+    componentElement = React.createElement(ComponentClass, {
+      component: 'List',
+      dataUrl: 'users.json'
+    });
+    componentInstance = utils.renderIntoDocument(componentElement);
 
     var router = new Cosmos.Router();
     // We alter the current instance while it's bound to the current history
@@ -140,6 +212,8 @@ describe("Cosmos.Router", function() {
     // shouldn't been updated with our changes
     router.goTo('?component=User&dataUrl=user.json');
 
+    // It's a bit difficult to mock the native functions so we mocked the
+    // private methods that wrap those calls
     expect(router._replaceHistoryState.calls.count()).toEqual(1);
     expect(router._replaceHistoryState.calls.mostRecent().args[0]).toEqual({
       component: 'List',

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -123,10 +123,7 @@ describe("Cosmos.Router", function() {
           return React.DOM.span();
         }
       });
-      componentElement = React.createElement(ComponentClass, {
-        component: 'List',
-        dataUrl: 'users.json'
-      });
+      componentElement = React.createElement(ComponentClass);
       componentInstance = utils.renderIntoDocument(componentElement);
 
       // Simulate some state addition in the component

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -200,6 +200,37 @@ describe("Cosmos.Router", function() {
       });
     });
 
+    it("shouldn't push router instance to browser history", function() {
+      ComponentClass = React.createClass({
+        mixins: [Cosmos.mixins.PersistState],
+        render: function() {
+          return React.DOM.span();
+        }
+      });
+      componentElement = React.createElement(ComponentClass);
+      componentInstance = utils.renderIntoDocument(componentElement);
+
+      var router = new Cosmos.Router();
+
+      spyOn(componentInstance, 'generateSnapshot').and.callFake(function() {
+        return {
+          component: 'List',
+          dataUrl: 'users.json',
+          router: router
+        };
+      });
+
+      router.goTo('?component=List&dataUrl=users.json');
+
+      // Simulate React.render callback call
+      componentCallback.call(componentInstance);
+
+      // It's a bit difficult to mock the native functions so we mocked the
+      // private methods that wrap those calls
+      var propsSent = router._pushHistoryState.calls.mostRecent().args[0];
+      expect(propsSent.router).toBe(undefined);
+    });
+
     it("should update browser history for previous component", function() {
       /* Note: This is not a pure unit test, it depends on the internal logic
       of React components */

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -106,8 +106,6 @@ describe("Cosmos.Router", function() {
     var router = new Cosmos.Router();
     router.goTo('?component=List&dataUrl=users.json');
 
-    expect(Cosmos.render.calls.count()).toEqual(2);
-
     var propsSent = Cosmos.render.calls.mostRecent().args[0];
     expect(propsSent.component).toEqual('List');
     expect(propsSent.dataUrl).toEqual('users.json');
@@ -119,8 +117,6 @@ describe("Cosmos.Router", function() {
       defaultProp: true
     });
     router.goTo('?component=List&dataUrl=users.json');
-
-    expect(Cosmos.render.calls.count()).toEqual(2);
 
     var propsSent = Cosmos.render.calls.mostRecent().args[0];
     expect(propsSent.component).toEqual('List');
@@ -159,14 +155,11 @@ describe("Cosmos.Router", function() {
     // Simulate React.render callback call
     componentCallback.call(componentInstance, 'testx');
 
-    // The snapshot shouldn't been extracted from the component two times
-    // 1. For previous component
-    // 2. For just loaded component
-    expect(componentInstance.generateSnapshot.calls.count()).toEqual(2);
+    // The snapshot should've been extracted from the component
+    expect(componentInstance.generateSnapshot).toHaveBeenCalled();
 
     // It's a bit difficult to mock the native functions so we mocked the
     // private methods that wrap those calls
-    expect(router._pushHistoryState.calls.count()).toEqual(1);
     expect(router._pushHistoryState.calls.mostRecent().args[0]).toEqual({
       component: 'List',
       dataUrl: 'users.json',
@@ -184,8 +177,6 @@ describe("Cosmos.Router", function() {
         dataUrl: 'users.json'
       }
     });
-
-    expect(Cosmos.render.calls.count()).toEqual(2);
 
     var propsSent = Cosmos.render.calls.mostRecent().args[0];
     expect(propsSent.component).toEqual('List');
@@ -237,7 +228,6 @@ describe("Cosmos.Router", function() {
 
     // It's a bit difficult to mock the native functions so we mocked the
     // private methods that wrap those calls
-    expect(router._replaceHistoryState.calls.count()).toEqual(1);
     expect(router._replaceHistoryState.calls.mostRecent().args[0]).toEqual({
       component: 'List',
       dataUrl: null,

--- a/specs/lib-router-spec.js
+++ b/specs/lib-router-spec.js
@@ -14,18 +14,22 @@ describe("Cosmos.Router", function() {
     global.window = jsdom.jsdom().createWindow('<html><body></body></html>');
     global.document = global.window.document;
     global.navigator = global.window.navigator;
-    // We're mocking the URL query string of the window
-    global.window.location = {search: '?component=List&data=users.json'};
 
     React = require('react/addons');
     utils = React.addons.TestUtils;
     Cosmos = require('../build/cosmos.js');
 
-    // Ignore out of scope methods
+    // Ignore external methods
     spyOn(Cosmos.Router.prototype, '_bindPopStateEvent');
     spyOn(Cosmos.Router.prototype, '_replaceHistoryState');
     spyOn(Cosmos.Router.prototype, '_pushHistoryState');
     spyOn(Cosmos.url, 'isPushStateSupported').and.returnValue(true);
+
+    // The Cosmos.url lib is already tested in isolation
+    spyOn(Cosmos.url, 'getParams').and.returnValue({
+      component: 'List',
+      data: 'users.json'
+    });
   });
 
   describe("new instance", function() {
@@ -135,7 +139,7 @@ describe("Cosmos.Router", function() {
     // Before routing to a new Component configuration, the previous one
     // shouldn't been updated with our changes
     router.goTo('?component=User&dataUrl=user.json');
-    
+
     expect(router._replaceHistoryState.calls.count()).toEqual(1);
     expect(router._replaceHistoryState.calls.mostRecent().args[0]).toEqual({
       component: 'List',

--- a/specs/lib-serialize-spec.js
+++ b/specs/lib-serialize-spec.js
@@ -1,0 +1,94 @@
+describe("Cosmos.serialize", function() {
+
+  var jsdom = require('jsdom');
+
+  // jsdom creates a fresh new window object for every test case and React needs
+  // to be required *after* the window and document globals are available. The
+  // var references however must be declared globally in order to be accessible
+  // in test cases as well.
+  var React,
+      utils,
+      Cosmos,
+      queryString,
+      props;
+
+  beforeEach(function() {
+    global.window = jsdom.jsdom().createWindow('<html><body></body></html>');
+    global.document = global.window.document;
+    global.navigator = global.window.navigator;
+
+    React = require('react/addons');
+    utils = React.addons.TestUtils;
+    Cosmos = require('../build/cosmos.js');
+  });
+
+  it("should generate props object from query string", function() {
+    queryString = 'component=List&dataUrl=users.json';
+    props = Cosmos.serialize.getPropsFromQueryString(queryString);
+
+    expect(props).toEqual({
+      component: 'List',
+      dataUrl: 'users.json'
+    });
+  });
+
+  it("should decode encoded params from query string", function() {
+    queryString = 'component=List&prop=word%20with%20spaces';
+    props = Cosmos.serialize.getPropsFromQueryString(queryString);
+
+    expect(props).toEqual({
+      component: 'List',
+      prop: 'word with spaces'
+    });
+  });
+
+  it("should parse stringified JSON from query string", function() {
+    queryString = 'component=List&prop=' +
+                  '%7B%22iam%22%3A%7B%22nested%22%3Atrue%7D%7D';
+    props = Cosmos.serialize.getPropsFromQueryString(queryString);
+
+    expect(props).toEqual({
+      component: 'List',
+      prop: {
+        iam: {
+          nested: true
+        }
+      }
+    });
+  });
+
+  it("should generate query string from props", function() {
+    props = {
+      component: 'List',
+      dataUrl: 'users.json'
+    };
+    queryString = Cosmos.serialize.getQueryStringFromProps(props);
+
+    expect(queryString).toEqual('component=List&dataUrl=users.json');
+  });
+
+  it("should encode params in query string", function() {
+    props = {
+      component: 'List',
+      prop: 'word with spaces'
+    };
+    queryString = Cosmos.serialize.getQueryStringFromProps(props);
+
+    expect(queryString).toEqual('component=List&prop=word%20with%20spaces');
+  });
+
+  it("should stringify JSON in query string", function() {
+    props = {
+      component: 'List',
+      prop: {
+        iam: {
+          nested: true
+        }
+      }
+    };
+    queryString = Cosmos.serialize.getQueryStringFromProps(props);
+
+    expect(queryString).toEqual('component=List&prop=' +
+                                '%7B%22iam%22%3A%7B%22nested%22%3Atrue%7D%7D');
+  });
+});

--- a/specs/lib-url-spec.js
+++ b/specs/lib-url-spec.js
@@ -20,10 +20,21 @@ describe("Cosmos.url", function() {
     React = require('react/addons');
     utils = React.addons.TestUtils;
     Cosmos = require('../build/cosmos.js');
+
+    // The Cosmos.serialize lib is already tested in isolation
+    spyOn(Cosmos.serialize, 'getPropsFromQueryString').and.returnValue({
+      component: 'List',
+      data: 'users.json'
+    });
   });
 
   it(".getParams should extract the query string from the URL", function() {
-    expect(Cosmos.url.getParams()).toEqual({
+    var props = Cosmos.url.getParams();
+
+    expect(Cosmos.serialize.getPropsFromQueryString)
+          .toHaveBeenCalledWith('component=List&data=users.json');
+
+    expect(props).toEqual({
       component: 'List',
       data: 'users.json'
     });

--- a/specs/mixin-url-spec.js
+++ b/specs/mixin-url-spec.js
@@ -19,10 +19,6 @@ describe("Components implementing the Url mixin", function() {
     React = require('react/addons');
     utils = React.addons.TestUtils;
     Cosmos = require('../build/cosmos.js');
-
-    // The Cosmos.serialize lib is already tested in isolation
-    spyOn(Cosmos.serialize, 'getQueryStringFromProps')
-         .and.returnValue('players=5&state=%7B%22speed%22%3A1%7D');
   });
 
   // In order to avoid any sort of state between tests, even the component class
@@ -42,6 +38,10 @@ describe("Components implementing the Url mixin", function() {
       componentInstance;
 
   it("should generate url with escaped props and state", function() {
+    // The Cosmos.serialize lib is already tested in isolation
+    spyOn(Cosmos.serialize, 'getQueryStringFromProps')
+         .and.returnValue('players=5&state=%7B%22speed%22%3A1%7D');
+
     ComponentClass = generateComponentClass();
     componentElement = React.createElement(ComponentClass, {
       players: 5,
@@ -61,5 +61,29 @@ describe("Components implementing the Url mixin", function() {
         speed: 1
       }
     });
+  });
+
+  it("should call props instance from props", function() {
+    var goToSpy = jasmine.createSpy();
+
+    ComponentClass = generateComponentClass();
+    componentElement = React.createElement(ComponentClass, {
+      router: {
+        goTo: goToSpy
+      }
+    });
+    componentInstance = utils.renderIntoDocument(componentElement);
+
+    // Fake the structure of an event
+    componentInstance.routeLink({
+      preventDefault: function() {},
+      currentTarget: {
+        getAttribute: function() {
+          return '?component=NextComponent';
+        }
+      }
+    });
+
+    expect(goToSpy).toHaveBeenCalledWith('?component=NextComponent');
   });
 });

--- a/specs/mixin-url-spec.js
+++ b/specs/mixin-url-spec.js
@@ -19,6 +19,10 @@ describe("Components implementing the Url mixin", function() {
     React = require('react/addons');
     utils = React.addons.TestUtils;
     Cosmos = require('../build/cosmos.js');
+
+    // The Cosmos.serialize lib is already tested in isolation
+    spyOn(Cosmos.serialize, 'getQueryStringFromProps')
+         .and.returnValue('players=5&state=%7B%22speed%22%3A1%7D');
   });
 
   // In order to avoid any sort of state between tests, even the component class
@@ -41,12 +45,21 @@ describe("Components implementing the Url mixin", function() {
     ComponentClass = generateComponentClass();
     componentElement = React.createElement(ComponentClass, {
       players: 5,
-      state: {speed: 1}
+      state: {
+        speed: 1
+      }
     });
     componentInstance = utils.renderIntoDocument(componentElement);
 
     expect(componentInstance.getUrlFromProps(componentInstance.generateSnapshot()))
-          // encodeURIComponent(JSON.stringify({speed:1}))
+          // state=encodeURIComponent(JSON.stringify({speed:1}))
           .toEqual('?players=5&state=%7B%22speed%22%3A1%7D');
+
+    expect(Cosmos.serialize.getQueryStringFromProps).toHaveBeenCalledWith({
+      players: 5,
+      state: {
+        speed: 1
+      }
+    });
   });
 });


### PR DESCRIPTION
## Need

The Router at the moment:
- Receives two sets of props which is not very intuitive
- Doesn't support the componentLookup or other function props that can't be put in the browser history state
- Isn't fully encapsulated, requires a global `App` reference
- Unit tests are not complete nor correct (a lot of integration tests)

## Deliverables

- [x] The Router only receives one set of default props that works as the base of all props received later
- [x] The Router params should no longer be a props but just `(defaultProps, container)`
- [x] The Router ignores ~~unserializable props (functions or classes/class instances) when populating browser history state (they probably come from the default props anyway so they'll be present in every page)~~ default props
- [x] The Router passes its instance down to the root component and drop the global `App` nonsense
- [x] Every related lib/mixin should be tested

Optional: #27 

## Solution

Guidelines:

- [x] Don't test private methods
- [x] Handlers passed to external modules aren't private (no `_` prefix)
- [x] No more expects that aren't relevant 