### PR TITLE
Improve check for component class

### DIFF
--- a/cosmos.js
+++ b/cosmos.js
@@ -7,8 +7,9 @@ _.extend(Cosmos, {
   mixins: {},
   components: {},
   transitions: {},
-  start: function(options) {
-    return new this.Router(options);
+
+  start: function(defaultProps, container) {
+    return new this.Router(defaultProps, container);
   },
   render: function(props, container, callback) {
     var componentInstance = this.createElement(props);

--- a/cosmos.js
+++ b/cosmos.js
@@ -11,22 +11,28 @@ _.extend(Cosmos, {
   start: function(defaultProps, container) {
     return new this.Router(defaultProps, container);
   },
+
   render: function(props, container, callback) {
     var componentInstance = this.createElement(props);
+
     if (container) {
       return React.render(componentInstance, container, callback);
     } else {
       return React.renderToString(componentInstance);
     }
   },
+
   createElement: function(props) {
     var ComponentClass = this.getComponentByName(props.component,
                                                  props.componentLookup);
+
     if (!_.isFunction(ComponentClass)) {
       throw new Error('Invalid component: ' + props.component);
     }
+
     return React.createElement(ComponentClass, props);
   },
+
   getComponentByName: function(name, componentLookup) {
     if (_.isFunction(componentLookup)) {
       var ComponentClass = componentLookup(name);

--- a/cosmos.js
+++ b/cosmos.js
@@ -22,7 +22,7 @@ _.extend(Cosmos, {
   createElement: function(props) {
     var ComponentClass = this.getComponentByName(props.component,
                                                  props.componentLookup);
-    if (!ComponentClass) {
+    if (!_.isFunction(ComponentClass)) {
       throw new Error('Invalid component: ' + props.component);
     }
     return React.createElement(ComponentClass, props);

--- a/cosmos.js
+++ b/cosmos.js
@@ -28,9 +28,16 @@ _.extend(Cosmos, {
     return React.createElement(ComponentClass, props);
   },
   getComponentByName: function(name, componentLookup) {
-    if (typeof(componentLookup) == 'function') {
-      return componentLookup(name);
+    if (_.isFunction(componentLookup)) {
+      var ComponentClass = componentLookup(name);
+
+      // Fall back to the Cosmos.components namespace if the lookup doesn't
+      // return anything. Needed for exposing built-in components in Cosmos
+      if (ComponentClass) {
+        return ComponentClass;
+      };
     }
+
     return this.components[name];
   }
 });

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -1,15 +1,15 @@
 Cosmos.mixins.PersistState = {
   /**
    * Heart of the Cosmos framework. Enables dumping a state object into a
-   * Component and exporting the current state.
+   * component and exporting the current state.
    *
    * Props:
-   *   - state: An object that will be poured inside the initial Component
+   *   - state: An object that will be poured inside the initial component
    *            state as soon as it loads (replacing any default state.)
    */
   generateSnapshot: function(recursive) {
     /**
-     * Generate a snapshot of the Component props (including current state.)
+     * Generate a snapshot of the component props (including current state.)
      * It excludes internal props set by React during run-time and props with
      * default values.
      */
@@ -17,19 +17,22 @@ Cosmos.mixins.PersistState = {
         value,
         state,
         children = {};
+
     for (var key in this.props) {
       value = this.props[key];
+
       // Ignore "system" props
       if (key == '__owner__' ||
-        // Current state should be used instead of initial one
-        key == 'state' ||
-        // No reason to include parent reference
-        key == 'ref') {
+          // Current state should be used instead of initial one
+          key == 'state') {
         continue;
       }
+
       props[key] = value;
     }
+
     props.state = _.cloneDeep(this.state) || {};
+
     if (recursive) {
       _.each(this.refs, function(instance, ref) {
         // The child component needs to implement the PeristState mixin to be
@@ -40,72 +43,86 @@ Cosmos.mixins.PersistState = {
           children[ref] = _.cloneDeep(instance.state) || {};
         }
       });
+
       if (!_.isEmpty(children)) {
         props.state.children = children;
       }
     }
+
     return props;
   },
+
   loadChild: function() {
     var childProps = this.getChildProps.apply(this, arguments);
     // Children are optional
     return childProps ? Cosmos.createElement(childProps) : null;
   },
-  /**
-   * @param {string} name - Key that corresponds to the child Component we want
-   *                        to get the props for
-   * @param {...*} [arguments] - Optional extra arguments get passed to the
-   *                             function that returns the Component props
-   */
+
   getChildProps: function(name) {
-    // The .children object on a Component class contains a hash of functions.
-    // Keys in this hash represent the name and by default the *refs* of child
-    // Components (unless changed via optional arguments passed in) and their
-    // values are functions that return props for each of those child Components.
+    /**
+     * @param {String} name Key that corresponds to the child component we want
+     *                      to get the props for
+     * @param {...*} [arguments] Optional extra arguments get passed to the
+     *                           function that returns the component props
+     */
     var args = [];
     for (var i = 1; i < arguments.length; ++i) {
       args[i - 1] = arguments[i];
     }
 
+    // The .children object on a component class contains a hash of functions.
+    // Keys in this hash represent the name and by default the *refs* of child
+    // components (unless changed via optional arguments passed in) and their
+    // values are functions that return props for each of those child
+    // components.
     var props = this.children[name].apply(this, args);
     if (!props) {
       return;
     }
-    // A tree of states can be embeded inside a single (root) Component input,
-    // trickling down recursively all the way to the tree leaves. Child states
-    // are set inside the .children key of the parent Component's state, as a
-    // hash with keys corresponding to Component *refs*. These preset states
-    // will be overriden with those generated at run-time.
+
     if (!props.ref) {
       props.ref = name;
     }
+
+    // A tree of states can be embeded inside a single (root) component input,
+    // trickling down recursively all the way to the tree leaves. Child states
+    // are set inside the .children key of the parent component's state, as a
+    // hash with keys corresponding to component *refs*. These preset states
+    // will be overriden with those generated at run-time.
     if (this._childSnapshots && this._childSnapshots[name]) {
       props.state = this._childSnapshots[name];
+      
       // Child snapshots are only used for first render after which organic
       // states are formed
       delete this._childSnapshots[name];
     }
+
     if (this.props.componentLookup) {
       props.componentLookup = this.props.componentLookup;
     }
+
     return props;
   },
+
   loadStateSnapshot: function(state) {
     if (state.children) {
       this._childSnapshots = state.children;
       delete state.children;
     }
+
     // Don't alter initial state object when changing state in the future
     this.replaceState(_.cloneDeep(state));
   },
+
   componentWillMount: function() {
     // Allow passing a serialized snapshot of a state through the props
     if (this.props.state) {
       this.loadStateSnapshot(this.props.state);
     }
   },
+
   componentWillReceiveProps: function(nextProps) {
-    // A Component can have its configuration replaced at any time
+    // A component can have its configuration replaced at any time
     if (nextProps.state) {
       this.loadStateSnapshot(nextProps.state);
     }

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -54,8 +54,17 @@ Cosmos.mixins.PersistState = {
 
   loadChild: function() {
     var childProps = this.getChildProps.apply(this, arguments);
-    // Children are optional
-    return childProps ? Cosmos.createElement(childProps) : null;
+
+    if (childProps) {
+      try {
+        return Cosmos.createElement(childProps);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    // Return null won't render any node
+    return null;
   },
 
   getChildProps: function(name) {
@@ -91,7 +100,7 @@ Cosmos.mixins.PersistState = {
     // will be overriden with those generated at run-time.
     if (this._childSnapshots && this._childSnapshots[name]) {
       props.state = this._childSnapshots[name];
-      
+
       // Child snapshots are only used for first render after which organic
       // states are formed
       delete this._childSnapshots[name];

--- a/specs/cosmos-spec.js
+++ b/specs/cosmos-spec.js
@@ -56,6 +56,20 @@ describe("Cosmos", function() {
            .toBe(DummyComponentClass);
   });
 
+  it("should fall back to Cosmos namespace after componentLookup", function() {
+    Cosmos.components.Dumber = {};
+
+    var componentLookup = function(name) {
+      // Return nothing, let Cosmos fall back
+      return;
+    };
+
+    expect(Cosmos.getComponentByName('Dumber', componentLookup))
+           .toBe(Cosmos.components.Dumber);
+
+    delete Cosmos.components.Dumber;
+  });
+
   describe(".createElement", function() {
 
     beforeEach(function() {

--- a/specs/cosmos-spec.js
+++ b/specs/cosmos-spec.js
@@ -140,11 +140,12 @@ describe("Cosmos", function() {
     });
 
     it("should pass args to Router constructor", function() {
-      var args = [{component: 'MyComponent'}, {container: '<div>'}];
+      var args = [{component: 'MyComponent'}, '<div>'];
 
-      Cosmos.start(args);
+      Cosmos.start.apply(Cosmos, args);
 
-      expect(Cosmos.Router.calls.mostRecent().args).toBe(args);
+      expect(Cosmos.Router.calls.mostRecent().args[0]).toBe(args[0]);
+      expect(Cosmos.Router.calls.mostRecent().args[1]).toBe(args[1]);
     });
 
     it("should return the Router instance", function() {

--- a/specs/cosmos-spec.js
+++ b/specs/cosmos-spec.js
@@ -60,10 +60,11 @@ describe("Cosmos", function() {
 
     beforeEach(function() {
       spyOn(React, 'createElement');
-      spyOn(Cosmos, 'getComponentByName').and.returnValue(DummyComponentClass);
     });
 
     it("should create React element for component class", function() {
+      spyOn(Cosmos, 'getComponentByName').and.returnValue(DummyComponentClass);
+
       // No need for a component lookup since we mocked
       // Cosmos.getComponentByName
       Cosmos.createElement({
@@ -75,6 +76,8 @@ describe("Cosmos", function() {
     });
 
     it("should create component element with props", function() {
+      spyOn(Cosmos, 'getComponentByName').and.returnValue(DummyComponentClass);
+
       // No need for a component lookup since we mocked
       // Cosmos.getComponentByName
       var props = {
@@ -84,6 +87,34 @@ describe("Cosmos", function() {
 
       expect(React.createElement.calls.mostRecent().args[1])
              .toEqual(props);
+    });
+
+    it("shouldn't instantiate component that's not a function", function() {
+      Cosmos.components.NotAFunction1 = 5;
+      Cosmos.components.NotAFunction2 = "string";
+      Cosmos.components.NotAFunction3 = [1, 2, 3];
+      Cosmos.components.NotAFunction4 = {x: true};
+
+      expect(function() {
+        Cosmos.createElement({component: 'NotAFunction1'});
+      }).toThrow();
+
+      expect(function() {
+        Cosmos.createElement({component: 'NotAFunction2'});
+      }).toThrow();
+
+      expect(function() {
+        Cosmos.createElement({component: 'NotAFunction3'});
+      }).toThrow();
+
+      expect(function() {
+        Cosmos.createElement({component: 'NotAFunction4'});
+      }).toThrow();
+
+      delete Cosmos.components.NotAFunction1;
+      delete Cosmos.components.NotAFunction2;
+      delete Cosmos.components.NotAFunction3;
+      delete Cosmos.components.NotAFunction4;
     });
   })
 

--- a/specs/mixins/persist-state-spec.js
+++ b/specs/mixins/persist-state-spec.js
@@ -54,11 +54,12 @@ describe("Components implementing the PersistState mixin", function() {
     expect(componentInstance.state).toEqual({foo: 'bar'});
   });
 
-  describe("child", function() {
+  describe("children", function() {
 
     beforeEach(function() {
       Cosmos.components.ChildComponent = generateComponentClass();
     });
+
     afterEach(function() {
       delete Cosmos.components.ChildComponent;
     });
@@ -342,8 +343,47 @@ describe("Components implementing the PersistState mixin", function() {
     expect(snapshot.state.nested.foo).toEqual('bar');
   });
 
+  it("should not throw error when child component is missing", function() {
+    spyOn(console, 'error');
 
-  describe("PersistState: dynamic children", function() {
+    ComponentClass = generateParentComponentClass({
+      children: {
+        childRef: function() {
+          return {
+            component: 'MissingChildComponent',
+            foo: 'bar'
+          };
+        }
+      }
+    });
+    componentElement = React.createElement(ComponentClass);
+
+    expect(function() {
+      componentInstance = utils.renderIntoDocument(componentElement);
+    }).not.toThrow();
+  });
+
+  it("should call console.error when child component is missing", function() {
+    spyOn(console, 'error');
+
+    ComponentClass = generateParentComponentClass({
+      children: {
+        childRef: function() {
+          return {
+            component: 'MissingChildComponent',
+            foo: 'bar'
+          };
+        }
+      }
+    });
+    componentElement = React.createElement(ComponentClass);
+    componentInstance = utils.renderIntoDocument(componentElement);
+
+    var error = new Error('Invalid component: MissingChildComponent');
+    expect(console.error).toHaveBeenCalledWith(error);
+  });
+
+  describe("dynamic children", function() {
     var chidren, childSpy;
 
     beforeEach(function() {


### PR DESCRIPTION
## Need

Sometimes Browserify returns an empty object for a module, thus passing [this condition](https://github.com/skidding/cosmos/blob/0.2.x/cosmos.js#L4)
And throwing an error when trying to call the component class from that module

## Deliverables

- Check if Class is a function before calling it, catch exception for children
  - [x] 0.2.x #89
  - [x] 0.3.x (with tests)

Also closes #79