### PR TITLE
Add onChange callback to Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,56 @@ to transform its input data into HTML output. Easy to follow and assert
 behavior. See [React Component](http://facebook.github.io/react/docs/component-api.html)
 for in-depth specs.
 
+Jump to:
+
+- [Top-level API](#top-level-api)
+- [Core concepts](#core-concepts)
+  - [Component lookup](#component-lookup)
+  - [State serialization](#state-serialization)
+  - [State injection](#state-injection)
+  - [Component tree](#component-tree)
+
+### Top-level API
+
+Cosmos can be used as the main router for a web app, but also just for
+rendering parts of an existent application.
+
+#### Cosmos.render(props, container, callback)
+
+Mere wrapper for React.render (or React.renderToString, if the `container`
+argument is missing), with the extra benefit of the
+[componentLookup.](#component-lookup)
+
+#### Cosmos.start(defaultProps, options)
+
+Entry point for a Cosmos Router-powered app. Uses the HTML5 history.pushState
+API to cache component snapshots and listen to state changes, rendering
+previous components in an instant when going back through history.
+
+The `defaultProps` are extended by the URL query string params. The `options`
+are as follows:
+
+- **container** - DOM container to render components in, defaults to
+                  `document.body`
+- **onChange(props)** - Called whenever the route changes (also initially),
+                        receiving the new props every time
+
+
+Here's how a standard URL for an app powered by the Cosmos Router would look
+like:
+
+```
+http://mydomain.com/?component=Father&eyes=blue&mood=happy
+```
+
+The [URL mixin](https://github.com/skidding/cosmos/wiki/Mixins#url) is used for
+routing links using the Cosmos Router.
+
+#### Mixins
+
+See the [Mixins wiki page](https://github.com/skidding/cosmos/wiki/Mixins) for
+information on the built-in mixins in Cosmos.
+
 ### Core concepts
 
 Reserved props when working with Cosmos: `component`, `componentLookup` and
@@ -117,7 +167,7 @@ var boy = Cosmos.render(props, document.body);
 
 > "a happy blue-eyed boy"
 
-#### Component snapshot
+#### State serialization
 
 The props and state of a component can be joined into a unified snapshot. The
 `state` prop holds the state of the component.
@@ -155,7 +205,7 @@ Serializing the state of components is no fun if we can't load it back later.
 var boyClone = Cosmos.render(boySnapshot);
 ```
 
-#### Children
+#### Component tree
 
 Cosmos gets interesting when dealing with nested components. The entire state
 of a component tree can be serialized recursively, as well as injected top-down
@@ -236,47 +286,6 @@ This is what the nested snapshot will look like:
 
 This makes it possible to capture the entire state of an application, persist
 it and then reproduce it in a different session.
-
-### Top-level API
-
-Cosmos can be used as the main router for a web app, but also just for
-rendering parts of an existent application.
-
-#### Cosmos.render(props, container, callback)
-
-Mere wrapper for React.render (or React.renderToString, if the `container`
-argument is missing), with the extra benefit of the
-[componentLookup.](#component-lookup)
-
-#### Cosmos.start(defaultProps, options)
-
-Entry point for a Cosmos Router-powered app. Uses the HTML5 history.pushState
-API to cache component snapshots and listen to state changes, rendering
-previous components in an instant when going back through history.
-
-The `defaultProps` are extended by the URL query string params. The `options`
-are as follows:
-
-- **container** - DOM container to render components in, defaults to
-                  `document.body`
-- **onChange(props)** - Called whenever the route changes (also initially),
-                        receiving the new props every time
-
-
-Here's how a standard URL for an app powered by the Cosmos Router would look
-like:
-
-```
-http://mydomain.com/?component=Father&eyes=blue&mood=happy
-```
-
-The [URL mixin](https://github.com/skidding/cosmos/wiki/Mixins#url) is used for
-routing links using the Cosmos Router.
-
-### Mixins
-
-Core mixins are placed under the `Cosmos.mixins` namespace. Read more in the
-[Mixins wiki page.](https://github.com/skidding/cosmos/wiki/Mixins)
 
 ## Problem
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,42 @@ This is what the nested snapshot will look like:
 This makes it possible to capture the entire state of an application, persist
 it and then reproduce it in a different session.
 
+### Top-level API
+
+Cosmos can be used as the main router for a web app, but also just for
+rendering parts of an existent application.
+
+#### Cosmos.render(props, container, callback)
+
+Mere wrapper for React.render (or React.renderToString, if the `container`
+argument is missing), with the extra benefit of the
+[componentLookup.](#component-lookup)
+
+#### Cosmos.start(defaultProps, options)
+
+Entry point for a Cosmos Router-powered app. Uses the HTML5 history.pushState
+API to cache component snapshots and listen to state changes, rendering
+previous components in an instant when going back through history.
+
+The `defaultProps` are extended by the URL query string params. The `options`
+are as follows:
+
+- **container** - DOM container to render components in, defaults to
+                  `document.body`
+- **onChange(props)** - Called whenever the route changes (also initially),
+                        receiving the new props every time
+
+
+Here's how a standard URL for an app powered by the Cosmos Router would look
+like:
+
+```
+http://mydomain.com/?component=Father&eyes=blue&mood=happy
+```
+
+The [URL mixin](https://github.com/skidding/cosmos/wiki/Mixins#url) is used for
+routing links using the Cosmos Router.
+
 ### Mixins
 
 Core mixins are placed under the `Cosmos.mixins` namespace. Read more in the

--- a/component-playground.html
+++ b/component-playground.html
@@ -38,9 +38,22 @@ var fixtures = {
   }
 };
 
-var router = Cosmos.start({
+var props = {
   component: 'ComponentPlayground',
   fixtures: fixtures
+};
+
+var router = Cosmos.start(props, {
+  onChange: function(props) {
+    var title = 'React Component Playground';
+
+    // Set document title to the name of the selected fixture
+    if (props.fixturePath) {
+      title = props.fixturePath + ' – ' + title;
+    }
+
+    document.title = title;
+  }
 });
 
   </script>

--- a/cosmos.js
+++ b/cosmos.js
@@ -8,8 +8,8 @@ _.extend(Cosmos, {
   components: {},
   transitions: {},
 
-  start: function(defaultProps, container) {
-    return new this.Router(defaultProps, container);
+  start: function(defaultProps, options) {
+    return new this.Router(defaultProps, options);
   },
 
   render: function(props, container, callback) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -70,6 +70,10 @@ _.extend(Cosmos.Router, {
 
       // We use the current href when updating the current history entry
       this._currentHref = href;
+
+      if (_.isFunction(this._options.onChange)) {
+        this._options.onChange.call(this, newProps);
+      }
     },
 
     _bindPopStateEvent: function() {

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,6 +1,8 @@
-Cosmos.Router = function(defaultProps, container) {
+Cosmos.Router = function(defaultProps, options) {
   this._defaultProps = defaultProps || {};
-  this._container = container || document.body;
+  this._options = _.extend({
+    container: document.body
+  }, options);
 
   this.onPopState = this.onPopState.bind(this);
   this._bindPopStateEvent();
@@ -62,7 +64,9 @@ _.extend(Cosmos.Router, {
       var props = _.extend({router: this}, this._defaultProps, newProps);
 
       // The router exposes the instance of the currently rendered component
-      this.rootComponent = Cosmos.render(props, this._container, callback);
+      this.rootComponent = Cosmos.render(props,
+                                         this._options.container,
+                                         callback);
 
       // We use the current href when updating the current history entry
       this._currentHref = href;

--- a/specs/cosmos-spec.js
+++ b/specs/cosmos-spec.js
@@ -185,7 +185,7 @@ describe("Cosmos", function() {
     });
 
     it("should pass args to Router constructor", function() {
-      var args = [{component: 'MyComponent'}, '<div>'];
+      var args = [{component: 'MyComponent'}, {container: '<div>'}];
 
       Cosmos.start.apply(Cosmos, args);
 

--- a/specs/lib/router-spec.js
+++ b/specs/lib/router-spec.js
@@ -82,6 +82,15 @@ describe("Cosmos.Router", function() {
 
       expect(Cosmos.render.calls.mostRecent().args[1]).toBe(document.body);
     });
+
+    it("should use container node received in options", function() {
+      var container = document.createElement('div');
+      var router = new Cosmos.Router({}, {
+        container: container
+      });
+
+      expect(Cosmos.render.calls.mostRecent().args[1]).toBe(container);
+    });
   });
 
   describe(".goTo method", function() {

--- a/specs/lib/router-spec.js
+++ b/specs/lib/router-spec.js
@@ -91,6 +91,18 @@ describe("Cosmos.Router", function() {
 
       expect(Cosmos.render.calls.mostRecent().args[1]).toBe(container);
     });
+
+    it("should call onChange callback", function() {
+      var onChangeSpy = jasmine.createSpy();
+      var router = new Cosmos.Router({}, {
+        onChange: onChangeSpy
+      });
+
+      var propsSent = onChangeSpy.calls.mostRecent().args[0];
+      // Mocked url props, tested above
+      expect(propsSent.component).toEqual('List');
+      expect(propsSent.dataUrl).toEqual('users.json');
+    });
   });
 
   describe(".goTo method", function() {
@@ -276,6 +288,18 @@ describe("Cosmos.Router", function() {
         }
       });
     });
+
+    it("should call onChange callback", function() {
+      var onChangeSpy = jasmine.createSpy();
+      var router = new Cosmos.Router({}, {
+        onChange: onChangeSpy
+      });
+      router.goTo('?component=MyComponent&myProp=true');
+
+      var propsSent = onChangeSpy.calls.mostRecent().args[0];
+      expect(propsSent.component).toEqual('MyComponent');
+      expect(propsSent.myProp).toEqual(true);
+    });
   });
 
   describe(".PopState event", function() {
@@ -323,6 +347,23 @@ describe("Cosmos.Router", function() {
 
       var propsSent = Cosmos.render.calls.mostRecent().args[0];
       expect(propsSent.router).toEqual(router);
+    });
+
+    it("should call onChange callback", function() {
+      var onChangeSpy = jasmine.createSpy();
+      var router = new Cosmos.Router({}, {
+        onChange: onChangeSpy
+      });
+      router.onPopState({
+        state: {
+          component: 'MyComponent',
+          myProp: true
+        }
+      });
+
+      var propsSent = onChangeSpy.calls.mostRecent().args[0];
+      expect(propsSent.component).toEqual('MyComponent');
+      expect(propsSent.myProp).toEqual(true);
     });
   });
 });

--- a/vendor/cosmos-0.3.0.js
+++ b/vendor/cosmos-0.3.0.js
@@ -23,36 +23,52 @@ _.extend(Cosmos, {
   mixins: {},
   components: {},
   transitions: {},
-  start: function(options) {
-    return new this.Router(options);
+
+  start: function(defaultProps, options) {
+    return new this.Router(defaultProps, options);
   },
+
   render: function(props, container, callback) {
     var componentInstance = this.createElement(props);
+
     if (container) {
       return React.render(componentInstance, container, callback);
     } else {
       return React.renderToString(componentInstance);
     }
   },
+
   createElement: function(props) {
     var ComponentClass = this.getComponentByName(props.component,
                                                  props.componentLookup);
-    if (!ComponentClass) {
+
+    if (!_.isFunction(ComponentClass)) {
       throw new Error('Invalid component: ' + props.component);
     }
+
     return React.createElement(ComponentClass, props);
   },
+
   getComponentByName: function(name, componentLookup) {
-    if (typeof(componentLookup) == 'function') {
-      return componentLookup(name);
+    if (_.isFunction(componentLookup)) {
+      var ComponentClass = componentLookup(name);
+
+      // Fall back to the Cosmos.components namespace if the lookup doesn't
+      // return anything. Needed for exposing built-in components in Cosmos
+      if (ComponentClass) {
+        return ComponentClass;
+      };
     }
+
     return this.components[name];
   }
 });
 
-Cosmos.Router = function(defaultProps, container) {
+Cosmos.Router = function(defaultProps, options) {
   this._defaultProps = defaultProps || {};
-  this._container = container || document.body;
+  this._options = _.extend({
+    container: document.body
+  }, options);
 
   this.onPopState = this.onPopState.bind(this);
   this._bindPopStateEvent();
@@ -114,10 +130,16 @@ _.extend(Cosmos.Router, {
       var props = _.extend({router: this}, this._defaultProps, newProps);
 
       // The router exposes the instance of the currently rendered component
-      this.rootComponent = Cosmos.render(props, this._container, callback);
+      this.rootComponent = Cosmos.render(props,
+                                         this._options.container,
+                                         callback);
 
       // We use the current href when updating the current history entry
       this._currentHref = href;
+
+      if (_.isFunction(this._options.onChange)) {
+        this._options.onChange.call(this, newProps);
+      }
     },
 
     _bindPopStateEvent: function() {
@@ -467,15 +489,15 @@ Cosmos.mixins.DataFetch = {
 Cosmos.mixins.PersistState = {
   /**
    * Heart of the Cosmos framework. Enables dumping a state object into a
-   * Component and exporting the current state.
+   * component and exporting the current state.
    *
    * Props:
-   *   - state: An object that will be poured inside the initial Component
+   *   - state: An object that will be poured inside the initial component
    *            state as soon as it loads (replacing any default state.)
    */
   generateSnapshot: function(recursive) {
     /**
-     * Generate a snapshot of the Component props (including current state.)
+     * Generate a snapshot of the component props (including current state.)
      * It excludes internal props set by React during run-time and props with
      * default values.
      */
@@ -483,19 +505,22 @@ Cosmos.mixins.PersistState = {
         value,
         state,
         children = {};
+
     for (var key in this.props) {
       value = this.props[key];
+
       // Ignore "system" props
       if (key == '__owner__' ||
-        // Current state should be used instead of initial one
-        key == 'state' ||
-        // No reason to include parent reference
-        key == 'ref') {
+          // Current state should be used instead of initial one
+          key == 'state') {
         continue;
       }
+
       props[key] = value;
     }
+
     props.state = _.cloneDeep(this.state) || {};
+
     if (recursive) {
       _.each(this.refs, function(instance, ref) {
         // The child component needs to implement the PeristState mixin to be
@@ -506,72 +531,95 @@ Cosmos.mixins.PersistState = {
           children[ref] = _.cloneDeep(instance.state) || {};
         }
       });
+
       if (!_.isEmpty(children)) {
         props.state.children = children;
       }
     }
+
     return props;
   },
+
   loadChild: function() {
     var childProps = this.getChildProps.apply(this, arguments);
-    // Children are optional
-    return childProps ? Cosmos.createElement(childProps) : null;
+
+    if (childProps) {
+      try {
+        return Cosmos.createElement(childProps);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    // Return null won't render any node
+    return null;
   },
-  /**
-   * @param {string} name - Key that corresponds to the child Component we want
-   *                        to get the props for
-   * @param {...*} [arguments] - Optional extra arguments get passed to the
-   *                             function that returns the Component props
-   */
+
   getChildProps: function(name) {
-    // The .children object on a Component class contains a hash of functions.
-    // Keys in this hash represent the name and by default the *refs* of child
-    // Components (unless changed via optional arguments passed in) and their
-    // values are functions that return props for each of those child Components.
+    /**
+     * @param {String} name Key that corresponds to the child component we want
+     *                      to get the props for
+     * @param {...*} [arguments] Optional extra arguments get passed to the
+     *                           function that returns the component props
+     */
     var args = [];
     for (var i = 1; i < arguments.length; ++i) {
       args[i - 1] = arguments[i];
     }
 
+    // The .children object on a component class contains a hash of functions.
+    // Keys in this hash represent the name and by default the *refs* of child
+    // components (unless changed via optional arguments passed in) and their
+    // values are functions that return props for each of those child
+    // components.
     var props = this.children[name].apply(this, args);
     if (!props) {
       return;
     }
-    // A tree of states can be embeded inside a single (root) Component input,
-    // trickling down recursively all the way to the tree leaves. Child states
-    // are set inside the .children key of the parent Component's state, as a
-    // hash with keys corresponding to Component *refs*. These preset states
-    // will be overriden with those generated at run-time.
+
     if (!props.ref) {
       props.ref = name;
     }
+
+    // A tree of states can be embeded inside a single (root) component input,
+    // trickling down recursively all the way to the tree leaves. Child states
+    // are set inside the .children key of the parent component's state, as a
+    // hash with keys corresponding to component *refs*. These preset states
+    // will be overriden with those generated at run-time.
     if (this._childSnapshots && this._childSnapshots[name]) {
       props.state = this._childSnapshots[name];
+
       // Child snapshots are only used for first render after which organic
       // states are formed
       delete this._childSnapshots[name];
     }
+
     if (this.props.componentLookup) {
       props.componentLookup = this.props.componentLookup;
     }
+
     return props;
   },
+
   loadStateSnapshot: function(state) {
     if (state.children) {
       this._childSnapshots = state.children;
       delete state.children;
     }
+
     // Don't alter initial state object when changing state in the future
     this.replaceState(_.cloneDeep(state));
   },
+
   componentWillMount: function() {
     // Allow passing a serialized snapshot of a state through the props
     if (this.props.state) {
       this.loadStateSnapshot(this.props.state);
     }
   },
+
   componentWillReceiveProps: function(nextProps) {
-    // A Component can have its configuration replaced at any time
+    // A component can have its configuration replaced at any time
     if (nextProps.state) {
       this.loadStateSnapshot(nextProps.state);
     }


### PR DESCRIPTION
## Need

We need an event for when the route changed
To set the document title based on each route

## Deliverables

- [x] Router changes args to `(defaultProps, options`)
- [x] `router._container` => `router._options.container`
- [x] `Router.onChange` callback after each `_load` call (including initial)
- [x] Callback in `component-playground.html` that changes the title of the document based on the selected fixture
- [x] Document Top-level API