### PR TITLE
Redesign PersistState mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The props and state of a component can be joined into a unified snapshot. The
 // Why do people sleep at night?
 boy.setState({mood: 'curious'});
 
-var boySnapshot = boy.generateSnapshot();
+var boySnapshot = boy.serialize();
 ```
 
 This is what `boySnapshot` will look like:
@@ -264,7 +264,7 @@ We can now generate a recursive snapshot and take a capture of the nested
 state.
 
 ```js
-var familySnapshot = father.generateSnapshot(true);
+var familySnapshot = father.serialize(true);
 ```
 
 This is what the nested snapshot will look like:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Then, we attach components to that namespace.
 
 ```js
 components.Boy = React.createClass({
-  mixins: [Cosmos.mixins.PersistState],
+  mixins: [Cosmos.mixins.ComponentTree],
 
   getInitialState: function() {
     return {
@@ -212,11 +212,11 @@ Cosmos gets interesting when dealing with nested components. The entire state
 of a component tree can be serialized recursively, as well as injected top-down
 from the root component to the tree leaves.
 
-This is achieved through the `loadChild` API of the `PersistState` mixin.
+This is achieved through the `loadChild` API of the `ComponentTree` mixin.
 
 ```js
 components.Father = React.createClass({
-  mixins: [Cosmos.mixins.PersistState],
+  mixins: [Cosmos.mixins.ComponentTree],
 
   children: {
     son: function() {

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -6,7 +6,7 @@ Cosmos.components.ComponentPlayground = React.createClass({
    * components in isolation. It can either render the component full-screen or
    * with the navigation pane on the side.
    */
-  mixins: [Cosmos.mixins.PersistState,
+  mixins: [Cosmos.mixins.ComponentTree,
            Cosmos.mixins.Url],
 
   displayName: 'ComponentPlayground',

--- a/lib/router.js
+++ b/lib/router.js
@@ -28,7 +28,7 @@ _.extend(Cosmos.Router, {
       // lastest props and state, so that we resume it its exact form when/if
       // going back
       if (this.rootComponent) {
-        var snapshot = this.rootComponent.generateSnapshot();
+        var snapshot = this.rootComponent.serialize();
         this._replaceHistoryState(this._excludeDefaultProps(snapshot),
                                   this._currentHref);
       }
@@ -43,7 +43,7 @@ _.extend(Cosmos.Router, {
         // event, only a browser page change does. Otherwise this would've
         // triggered an infinite loop.
         // https://developer.mozilla.org/en-US/docs/Web/API/window.onpopstate
-        var snapshot = this.generateSnapshot();
+        var snapshot = this.serialize();
         _this._pushHistoryState(_this._excludeDefaultProps(snapshot), href);
       });
     },

--- a/mixins/animation-loop.js
+++ b/mixins/animation-loop.js
@@ -25,7 +25,7 @@ Cosmos.mixins.AnimationLoop = {
     this._loadAnimationState(this.state);
   },
   componentWillReceiveProps: function(nextProps) {
-    // This is a feature that only works in conjunction with the PersistState
+    // This is a feature that only works in conjunction with the ComponentTree
     // mixin. Animations will be resumed or stopped based on previous states
     // loaded using setProps({state: ...})
     if (nextProps.state) {

--- a/mixins/component-tree.js
+++ b/mixins/component-tree.js
@@ -1,4 +1,4 @@
-Cosmos.mixins.PersistState = {
+Cosmos.mixins.ComponentTree = {
   /**
    * Heart of the Cosmos framework. Enables dumping a state object into a
    * component and exporting the current state.

--- a/mixins/component-tree.js
+++ b/mixins/component-tree.js
@@ -19,10 +19,8 @@ Cosmos.mixins.ComponentTree = {
     for (var key in this.props) {
       value = this.props[key];
 
-      // Ignore "system" props
-      if (key == '__owner__' ||
-          // Current state should be used instead of initial one
-          key == 'state') {
+      // Current state should be used instead of initial one
+      if (key == 'state') {
         continue;
       }
 

--- a/mixins/component-tree.js
+++ b/mixins/component-tree.js
@@ -1,17 +1,13 @@
 Cosmos.mixins.ComponentTree = {
   /**
-   * Heart of the Cosmos framework. Enables dumping a state object into a
-   * component and exporting the current state.
-   *
-   * Props:
-   *   - state: An object that will be poured inside the initial component
-   *            state as soon as it loads (replacing any default state.)
+   * Heart of the Cosmos framework. Links components with their children
+   * recursively. This makes it possible to inject nested state intro a tree of
+   * compoents, as well as serializing them into a single snapshot.
    */
   serialize: function(recursive) {
     /**
-     * Generate a snapshot of the component props (including current state.)
-     * It excludes internal props set by React during run-time and props with
-     * default values.
+     * Generate a snapshot with the the props and state of a component
+     * combined, including the state of all nested child components.
      */
     var snapshot = {},
         value;
@@ -33,8 +29,8 @@ Cosmos.mixins.ComponentTree = {
 
     if (recursive) {
       _.each(this.refs, function(child, ref) {
-        // The child component needs to implement the PeristState mixin to be
-        // able to serialize its children recursively as well
+        // We can only nest child state if the child component also uses the
+        // ComponentTree mixin
         if (_.isFunction(child.serialize)) {
           childSnapshot = child.serialize(true);
 

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -37,7 +37,7 @@ Cosmos.mixins.PersistState = {
       _.each(this.refs, function(instance, ref) {
         // The child component needs to implement the PeristState mixin to be
         // able to serialize its children recursively as well
-        if (typeof(instance.serialize) == 'function') {
+        if (_.isFunction(instance.serialize)) {
           childSnapshot = instance.serialize(true);
 
           if (!_.isEmpty(childSnapshot.state)) {

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -82,6 +82,7 @@ Cosmos.mixins.PersistState = {
      * @param {...*} [arguments] Optional extra arguments get passed to the
      *                           function that returns the component props
      */
+    // https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
     var args = [];
     for (var i = 1; i < arguments.length; ++i) {
       args[i - 1] = arguments[i];

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -74,10 +74,8 @@ Cosmos.mixins.PersistState = {
      * @param {...*} [arguments] Optional extra arguments get passed to the
      *                           function that returns the component props
      */
-    var args = [];
-    for (var i = 1; i < arguments.length; ++i) {
-      args[i - 1] = arguments[i];
-    }
+    // The first argument is the child name, the rest are splat params
+    var args = Array.prototype.splice.call(arguments, 1);
 
     // The .children object on a component class contains a hash of functions.
     // Keys in this hash represent the name and by default the *refs* of child

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -34,11 +34,11 @@ Cosmos.mixins.PersistState = {
         childSnapshot;
 
     if (recursive) {
-      _.each(this.refs, function(instance, ref) {
+      _.each(this.refs, function(child, ref) {
         // The child component needs to implement the PeristState mixin to be
         // able to serialize its children recursively as well
-        if (_.isFunction(instance.serialize)) {
-          childSnapshot = instance.serialize(true);
+        if (_.isFunction(child.serialize)) {
+          childSnapshot = child.serialize(true);
 
           if (!_.isEmpty(childSnapshot.state)) {
             children[ref] = childSnapshot.state;

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -82,8 +82,10 @@ Cosmos.mixins.PersistState = {
      * @param {...*} [arguments] Optional extra arguments get passed to the
      *                           function that returns the component props
      */
-    // The first argument is the child name, the rest are splat params
-    var args = Array.prototype.splice.call(arguments, 1);
+    var args = [];
+    for (var i = 1; i < arguments.length; ++i) {
+      args[i - 1] = arguments[i];
+    }
 
     // The .children object on a component class contains a hash of functions.
     // Keys in this hash represent the name and by default the *refs* of child

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -107,8 +107,8 @@ Cosmos.mixins.PersistState = {
     // are set inside the .children key of the parent component's state, as a
     // hash with keys corresponding to component *refs*. These preset states
     // will be overriden with those generated at run-time.
-    if (this._childSnapshots && this._childSnapshots[name]) {
-      props.state = this._childSnapshots[name];
+    if (this._childSnapshots && this._childSnapshots[props.ref]) {
+      props.state = this._childSnapshots[props.ref];
     }
 
     if (this.props.componentLookup) {

--- a/mixins/persist-state.js
+++ b/mixins/persist-state.js
@@ -126,17 +126,6 @@ Cosmos.mixins.PersistState = {
     this._clearChildSnapshots();
   },
 
-  componentWillReceiveProps: function(nextProps) {
-    // A component can have its state replaced at any time
-    if (nextProps.state) {
-      this._loadStateSnapshot(nextProps.state);
-    }
-  },
-
-  componentDidUpdate: function() {
-    this._clearChildSnapshots();
-  },
-
   _loadStateSnapshot: function(newState) {
     // Child snapshots are read and flushed on every render (through the
     // .children functions)

--- a/mixins/url.js
+++ b/mixins/url.js
@@ -7,8 +7,8 @@ Cosmos.mixins.Url = {
     /**
      * Serializes a props object into a browser-complient URL. The URL
      * generated can be simply put inside the href attribute of an <a> tag, and
-     * can be combined with the generateSnapshot method of the PersistState
-     * Mixin to create a link that opens the current Component at root level
+     * can be combined with the serialize method of the PersistState Mixin to
+     * create a link that opens the current Component at root level
      * (full window.)
      */
     return '?' + Cosmos.serialize.getQueryStringFromProps(props);

--- a/mixins/url.js
+++ b/mixins/url.js
@@ -7,7 +7,7 @@ Cosmos.mixins.Url = {
     /**
      * Serializes a props object into a browser-complient URL. The URL
      * generated can be simply put inside the href attribute of an <a> tag, and
-     * can be combined with the serialize method of the PersistState Mixin to
+     * can be combined with the serialize method of the ComponentTree Mixin to
      * create a link that opens the current Component at root level
      * (full window.)
      */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosmos-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A foundation for maintainable web applications",
   "repository": {
     "type": "git",

--- a/specs/lib/router-spec.js
+++ b/specs/lib/router-spec.js
@@ -148,7 +148,7 @@ describe("Cosmos.Router", function() {
       componentInstance = utils.renderIntoDocument(componentElement);
 
       // Simulate some state addition in the component
-      spyOn(componentInstance, 'generateSnapshot').and.callFake(function() {
+      spyOn(componentInstance, 'serialize').and.callFake(function() {
         return {
           component: 'List',
           dataUrl: 'users.json',
@@ -165,7 +165,7 @@ describe("Cosmos.Router", function() {
       componentCallback.call(componentInstance);
 
       // The snapshot should've been extracted from the component
-      expect(componentInstance.generateSnapshot).toHaveBeenCalled();
+      expect(componentInstance.serialize).toHaveBeenCalled();
 
       // It's a bit difficult to mock the native functions so we mocked the
       // private methods that wrap those calls
@@ -192,7 +192,7 @@ describe("Cosmos.Router", function() {
         // This won't be called because Cosmos.render is mocked
       };
 
-      spyOn(componentInstance, 'generateSnapshot').and.callFake(function() {
+      spyOn(componentInstance, 'serialize').and.callFake(function() {
         return {
           component: 'List',
           componentLookup: componentLookup,
@@ -233,7 +233,7 @@ describe("Cosmos.Router", function() {
 
       var router = new Cosmos.Router();
 
-      spyOn(componentInstance, 'generateSnapshot').and.callFake(function() {
+      spyOn(componentInstance, 'serialize').and.callFake(function() {
         return {
           component: 'List',
           dataUrl: 'users.json',

--- a/specs/lib/router-spec.js
+++ b/specs/lib/router-spec.js
@@ -139,7 +139,7 @@ describe("Cosmos.Router", function() {
 
     it("should push component snapshot to browser history", function() {
       ComponentClass = React.createClass({
-        mixins: [Cosmos.mixins.PersistState],
+        mixins: [Cosmos.mixins.ComponentTree],
         render: function() {
           return React.DOM.span();
         }
@@ -180,7 +180,7 @@ describe("Cosmos.Router", function() {
 
     it("shouldn't push default props to browser history", function() {
       ComponentClass = React.createClass({
-        mixins: [Cosmos.mixins.PersistState],
+        mixins: [Cosmos.mixins.ComponentTree],
         render: function() {
           return React.DOM.span();
         }
@@ -223,7 +223,7 @@ describe("Cosmos.Router", function() {
 
     it("shouldn't push router instance to browser history", function() {
       ComponentClass = React.createClass({
-        mixins: [Cosmos.mixins.PersistState],
+        mixins: [Cosmos.mixins.ComponentTree],
         render: function() {
           return React.DOM.span();
         }
@@ -256,7 +256,7 @@ describe("Cosmos.Router", function() {
       /* Note: This is not a pure unit test, it depends on the internal logic
       of React components */
       ComponentClass = React.createClass({
-        mixins: [Cosmos.mixins.PersistState],
+        mixins: [Cosmos.mixins.ComponentTree],
         render: function() {
           return React.DOM.span();
         }

--- a/specs/mixins/animation-loop-spec.js
+++ b/specs/mixins/animation-loop-spec.js
@@ -97,7 +97,7 @@ describe("Components implementing the AnimationLoop mixin", function() {
       var onFrameSpy = jasmine.createSpy('onFrame'),
           snapshot;
       ComponentClass = generateComponentClass({
-        mixins: [Cosmos.mixins.PersistState,
+        mixins: [Cosmos.mixins.ComponentTree,
                  Cosmos.mixins.AnimationLoop],
         onFrame: onFrameSpy
       });
@@ -124,7 +124,7 @@ describe("Components implementing the AnimationLoop mixin", function() {
       var onFrameSpy = jasmine.createSpy('onFrame'),
           snapshot;
       ComponentClass = generateComponentClass({
-        mixins: [Cosmos.mixins.PersistState,
+        mixins: [Cosmos.mixins.ComponentTree,
                  Cosmos.mixins.AnimationLoop],
         onFrame: onFrameSpy
       });

--- a/specs/mixins/animation-loop-spec.js
+++ b/specs/mixins/animation-loop-spec.js
@@ -104,7 +104,7 @@ describe("Components implementing the AnimationLoop mixin", function() {
       componentElement = React.createElement(ComponentClass);
       componentInstance = utils.renderIntoDocument(componentElement);
       componentInstance.startAnimationLoop();
-      snapshot = componentInstance.generateSnapshot();
+      snapshot = componentInstance.serialize();
       componentInstance.stopAnimationLoop();
 
       // Make sure calls weren't from the 1st Component
@@ -131,7 +131,7 @@ describe("Components implementing the AnimationLoop mixin", function() {
       componentElement = React.createElement(ComponentClass);
       componentInstance = utils.renderIntoDocument(componentElement);
       componentInstance.stopAnimationLoop();
-      snapshot = componentInstance.generateSnapshot();
+      snapshot = componentInstance.serialize();
       componentInstance.startAnimationLoop();
 
       // Make sure animation runs until loading stopped state

--- a/specs/mixins/component-tree-spec.js
+++ b/specs/mixins/component-tree-spec.js
@@ -1,4 +1,4 @@
-describe("Components implementing the PersistState mixin", function() {
+describe("Components implementing the ComponentTree mixin", function() {
 
   var _ = require('lodash'),
       jsdom = require('jsdom');
@@ -33,7 +33,7 @@ describe("Components implementing the PersistState mixin", function() {
 
     // The class spec and props will be extended or overriden in each test
     componentClassSpec = {
-      mixins: [Cosmos.mixins.PersistState],
+      mixins: [Cosmos.mixins.ComponentTree],
 
       render: function() {
         return React.DOM.span();

--- a/specs/mixins/persist-state-spec.js
+++ b/specs/mixins/persist-state-spec.js
@@ -237,6 +237,37 @@ describe("Components implementing the PersistState mixin", function() {
         expect(createElementProps.state).toBe(undefined);
       });
     });
+
+    it("should inject state into children with dynamic refs", function() {
+      componentClassSpec.children = {
+        son: function(nr) {
+          return {
+            ref: 'son' + nr
+          };
+        }
+      };
+      componentClassSpec.render = function() {
+        return React.DOM.div({}, [this.loadChild('son', 1),
+                                  this.loadChild('son', 2)]);
+      };
+
+      componentProps.state = {
+        children: {
+          son1: {
+            witty: true
+          },
+          son2: {
+            witty: false
+          }
+        }
+      };
+
+      renderComponent();
+
+      var createElementCalls = Cosmos.createElement.calls.allArgs();
+      expect(createElementCalls[0][0].state.witty).toBe(true);
+      expect(createElementCalls[1][0].state.witty).toBe(false);
+    });
   });
 
   describe("serializing", function() {

--- a/specs/mixins/persist-state-spec.js
+++ b/specs/mixins/persist-state-spec.js
@@ -184,24 +184,6 @@ describe("Components implementing the PersistState mixin", function() {
       expect(componentInstance.state.nevermind).toBe(true);
     });
 
-    it("should replace their state from the state prop", function() {
-      renderComponent();
-
-      componentInstance.setState({
-        mood: 'indiferent',
-        nevermind: true
-      });
-
-      componentInstance.setProps({
-        state: {
-          mood: 'interested'
-        }
-      });
-
-      expect(componentInstance.state.mood).toBe('interested');
-      expect(componentInstance.state.nevermind).toBe(undefined);
-    });
-
     it("should extend received state with initial state", function() {
       componentClassSpec.getInitialState = function() {
         return {

--- a/specs/mixins/persist-state-spec.js
+++ b/specs/mixins/persist-state-spec.js
@@ -9,7 +9,18 @@ describe("Components implementing the PersistState mixin", function() {
   // in test cases as well.
   var React,
       utils,
-      Cosmos;
+      Cosmos,
+      componentClassSpec,
+      ComponentClass,
+      componentProps,
+      componentElement,
+      componentInstance;
+
+  var renderComponent = function() {
+    ComponentClass = React.createClass(componentClassSpec);
+    componentElement = React.createElement(ComponentClass, componentProps);
+    componentInstance = utils.renderIntoDocument(componentElement);
+  };
 
   beforeEach(function() {
     global.window = jsdom.jsdom().createWindow('<html><body></body></html>');
@@ -19,454 +30,284 @@ describe("Components implementing the PersistState mixin", function() {
     React = require('react/addons');
     utils = React.addons.TestUtils;
     Cosmos = require('../../build/cosmos.js');
-  });
 
-  // Generate a new class from scratch for every test in order to avoid any
-  // on test affecting the other
-  var generateComponentClass = function(customAttributes) {
-    var defaultAttributes = {
+    // The class spec and props will be extended or overriden in each test
+    componentClassSpec = {
       mixins: [Cosmos.mixins.PersistState],
 
       render: function() {
         return React.DOM.span();
       }
     };
-
-    return React.createClass(_.extend({},
-                                      defaultAttributes,
-                                      customAttributes));
-  };
-
-  // This generator is helpful for parents with a generic child
-  var generateParentComponentClass = function(attributes) {
-    var defaultParentAttributes = {
-      render: function() {
-        return this.loadChild('myChild');
-      }
-    }
-
-    return generateComponentClass(_.extend({},
-                                           defaultParentAttributes,
-                                           attributes));
-  };
-
-  var ComponentClass,
-      componentElement,
-      componentInstance;
-
-  it("should load their state from the 'state' prop", function() {
-    ComponentClass = generateComponentClass();
-    componentElement = React.createElement(ComponentClass, {
-      state: {foo: 'bar'}
-    });
-    componentInstance = utils.renderIntoDocument(componentElement);
-
-    expect(componentInstance.state).toEqual({foo: 'bar'});
+    componentProps = {};
   });
 
-  it("should generate snapshot with exact props and state", function() {
-    ComponentClass = generateComponentClass();
-    componentElement = React.createElement(ComponentClass, {
-      players: 5,
-      state: {speed: 1}
-    });
-    componentInstance = utils.renderIntoDocument(componentElement);
-
-    expect(componentInstance.generateSnapshot())
-          .toEqual({players: 5, state: {speed: 1}});
-
-    // Let's ensure changes are also reflected in the snapshot
-    componentInstance.setProps({players: 10});
-    componentInstance.setState({speed: 3});
-    expect(componentInstance.generateSnapshot())
-          .toEqual({players: 10, state: {speed: 3}});
-  });
-
-  it("should generate snapshot recursively", function() {
-    Cosmos.components.ChildComponent = generateComponentClass();
-    ComponentClass = generateParentComponentClass({
-      children: {
-        myChild: function() {
-          return {
-            component: 'ChildComponent',
-            foo: 'bar'
-          };
-        }
-      }
-    });
-    componentElement = React.createElement(ComponentClass);
-    componentInstance = utils.renderIntoDocument(componentElement);
-    componentInstance.refs.myChild.setState({updated: true});
-
-    expect(componentInstance.generateSnapshot(true)).toEqual({
-      state: {
-        children: {
-          myChild: {
-            updated: true
-          }
-        }
-      }
-    });
-    delete Cosmos.components.ChildComponent;
-  });
-
-  it("should deep clone when generated snapshot", function() {
-    var snapshot,
-        nested;
-
-    ComponentClass = generateComponentClass();
-    componentElement = React.createElement(ComponentClass, {
-      state: {
-        nested: {foo: 'bar'}
-      }
-    });
-    componentInstance = utils.renderIntoDocument(componentElement);
-
-    snapshot = componentInstance.generateSnapshot();
-    nested = componentInstance.state.nested;
-    nested.foo = 'barbar';
-
-    componentInstance.setState({nested: nested});
-    expect(snapshot.state.nested.foo).toEqual('bar');
-  });
-
-  it("should deep clone when loading snapshot", function() {
-    var snapshot = {
-          state: {
-            nested: {foo: 'bar'}
-          }
-        },
-        nested;
-
-    ComponentClass = generateComponentClass(),
-    componentElement = React.createElement(ComponentClass, snapshot);
-    componentInstance = utils.renderIntoDocument(componentElement);
-
-    nested = componentInstance.state.nested;
-    nested.foo = 'barbar';
-
-    componentInstance.setState({nested: nested});
-    expect(snapshot.state.nested.foo).toEqual('bar');
-  });
-
-  it("should not throw error when child component is missing", function() {
-    spyOn(console, 'error');
-
-    ComponentClass = generateParentComponentClass({
-      children: {
-        myChild: function() {
-          return {
-            component: 'MissingChildComponent',
-            foo: 'bar'
-          };
-        }
-      }
-    });
-    componentElement = React.createElement(ComponentClass);
-
-    expect(function() {
-      componentInstance = utils.renderIntoDocument(componentElement);
-    }).not.toThrow();
-  });
-
-  it("should call console.error when child component is missing", function() {
-    spyOn(console, 'error');
-
-    ComponentClass = generateParentComponentClass({
-      children: {
-        myChild: function() {
-          return {
-            component: 'MissingChildComponent',
-            foo: 'bar'
-          };
-        }
-      }
-    });
-    componentElement = React.createElement(ComponentClass);
-    componentInstance = utils.renderIntoDocument(componentElement);
-
-    var error = new Error('Invalid component: MissingChildComponent');
-    expect(console.error).toHaveBeenCalledWith(error);
-  });
-
-  describe("children", function() {
+  describe("loading children", function() {
 
     beforeEach(function() {
-      Cosmos.components.ChildComponent = generateComponentClass();
+      spyOn(Cosmos, 'createElement');
     });
 
-    afterEach(function() {
-      delete Cosmos.components.ChildComponent;
-    });
-
-    it("props should be read from .children class handlers", function() {
-      ComponentClass = generateParentComponentClass({
-        children: {
-          myChild: function() {
-            return {
-              component: 'ChildComponent',
-              foo: 'bar'
-            };
-          }
-        }
-      });
-      componentElement = React.createElement(ComponentClass);
-      componentInstance = utils.renderIntoDocument(componentElement);
-
-      expect(componentInstance.refs.myChild.props).toEqual({
-        component: 'ChildComponent',
-        foo: 'bar'
-      });
-    });
-
-    it("state should be read from embedded .children state", function() {
-      ComponentClass = generateParentComponentClass({
-        children: {
-          myChild: function() {
-            return {
-              component: 'ChildComponent',
-              foo: 'bar'
-            };
-          }
-        }
-      });
-      componentElement = React.createElement(ComponentClass, {
-        state: {
-          children: {
-            myChild: {
-              isThisTheLife: true
-            }
-          }
-        }
-      });
-      componentInstance = utils.renderIntoDocument(componentElement);
-
-      expect(componentInstance.refs.myChild.state).toEqual({
-        isThisTheLife: true
-      });
-    });
-
-    it("should use embedded .children state first and then ignore it", function() {
-      ComponentClass = generateParentComponentClass({
-        children: {
-          myChild: function() {
-            return {
-              component: 'ChildComponent',
-              foo: this.props.foo
-            };
-          }
-        }
-      });
-      componentElement = React.createElement(ComponentClass, {
-        foo: 'bar',
-        state: {
-          children: {
-            myChild: {
-              isThisTheLife: true,
-              isThisLove: false
-            }
-          }
-        }
-      });
-      componentInstance = utils.renderIntoDocument(componentElement);
-
-      expect(componentInstance.refs.myChild.props).toEqual({
-        component: 'ChildComponent',
-        foo: 'bar',
-        state: {
-          isThisTheLife: true,
-          isThisLove: false
-        }
-      });
-      expect(componentInstance.refs.myChild.state).toEqual({
-        isThisTheLife: true,
-        isThisLove: false
-      });
-      // Child state should be preserved even after re-rendering parent
-      componentInstance.refs.myChild.setState({isThisLove: true});
-      // Re-render parent and child implicitly
-      componentInstance.setProps({foo: 'barbar'});
-      // Child state is no longer embedded when re-rendered by the parent
-      expect(componentInstance.refs.myChild.props).toEqual({
-        component: 'ChildComponent',
-        foo: 'barbar'
-      });
-      expect(componentInstance.refs.myChild.state).toEqual({
-        isThisTheLife: true,
-        isThisLove: true
-      });
-    });
-
-    it("should not interfere with sibling refs", function() {
-      ComponentClass = generateParentComponentClass({
-        children: {
-          myChild: function() {
-            return {
-              component: 'ChildComponent',
-              foo: this.props.foo
-            };
-          }
-        },
-        render: function() {
-          return React.DOM.div(null,
-            React.DOM.div(null, this.loadChild('myChild')),
-            React.DOM.div({ref: 'regularChild'}, this.props.foo)
-          );
-        }
-      });
-      componentElement = React.createElement(ComponentClass, {
-        foo: 'bar'
-      });
-      componentInstance = utils.renderIntoDocument(componentElement);
-
-      // Dynamic child is OK
-      expect(componentInstance.refs.myChild.props).toEqual({
-        component: 'ChildComponent',
-        foo: 'bar'
-      });
-
-      // Reg child is OK
-      expect(componentInstance.refs.regularChild)
-            .toEqual(jasmine.any(Object));
-      expect(componentInstance.refs.regularChild.getDOMNode().innerHTML)
-            .toEqual('bar');
-    });
-
-    it("should not interfere with child refs", function() {
-      Cosmos.components.ChildComponent = generateComponentClass({
-        render: function() {
-          return React.DOM.div(null,
-            React.DOM.div({ref: 'Refception'}, 'one'),
-            React.DOM.div({ref: 'LordOfTheRefs'}, 'two')
-          );
-        }
-      });
-
-      ComponentClass = generateParentComponentClass({
-        children: {
-          myChild: function() {
-            return {
-              component: 'ChildComponent'
-            };
-          }
-        }
-      });
-      componentElement = React.createElement(ComponentClass);
-      componentInstance = utils.renderIntoDocument(componentElement);
-
-      // Ref to child
-      expect(componentInstance.refs.myChild).toEqual(jasmine.any(Object));
-      // Refs of child
-      expect(componentInstance.refs.myChild.refs.Refception)
-            .toEqual(jasmine.any(Object));
-      expect(componentInstance.refs.myChild.refs.LordOfTheRefs)
-            .toEqual(jasmine.any(Object));
-      // Child refs contain references to DOM nodes
-      expect(componentInstance.refs.myChild.refs.Refception.getDOMNode().innerHTML)
-            .toEqual('one');
-      expect(componentInstance.refs.myChild.refs.LordOfTheRefs.getDOMNode().innerHTML)
-            .toEqual('two');
-    });
-
-    it("should propagate component lookup to children", function() {
-      var customComponents = {
-        StepChildComponent: generateComponentClass()
-      };
-      ComponentClass = generateParentComponentClass({
-        children: {
-          myChild: function() {
-            return {
-              component: 'StepChildComponent'
-            };
-          }
-        }
-      });
-      componentElement = React.createElement(ComponentClass, {
-        componentLookup: function(name) {
-          expect(name).toBe('StepChildComponent');
-          return customComponents[name];
-        }
-      });
-      componentInstance = utils.renderIntoDocument(componentElement);
-
-      // Child was found
-      expect(componentInstance.refs.myChild).toEqual(jasmine.any(Object));
-    });
-  });
-
-  describe("dynamic children", function() {
-    var chidren, childSpy;
-
-    beforeEach(function() {
-      children = {
-        myChild: function(customRef) {
+    it("should use props from .children function", function() {
+      componentClassSpec.children = {
+        son: function() {
           return {
-            foo: 'bar',
-            ref: customRef
+            component: 'Child',
+            age: 13
           };
         }
       };
-      childSpy = spyOn(children, 'myChild').and.callThrough();
 
-      spyOn(Cosmos, 'createElement').and.returnValue(React.createElement('div'));
+      renderComponent();
+      componentInstance.loadChild('son');
+
+      var createElementProps = Cosmos.createElement.calls.mostRecent().args[0];
+      expect(createElementProps.component).toBe('Child');
+      expect(createElementProps.age).toBe(13);
     });
 
-    it("should pass in empty arguments", function() {
-      ComponentClass = generateParentComponentClass({
-        children: children,
-        render: function() {
-          return this.loadChild('myChild');
+    it("should default ref to .children key", function() {
+      componentClassSpec.children = {
+        son: function() {
+          return {};
         }
-      });
-      componentElement = React.createElement(ComponentClass);
-      componentInstance = utils.renderIntoDocument(componentElement);
+      };
 
-      expect(childSpy).toHaveBeenCalledWith();
+      renderComponent();
+      componentInstance.loadChild('son');
+
+      var createElementProps = Cosmos.createElement.calls.mostRecent().args[0];
+      expect(createElementProps.ref).toBe('son');
     });
 
-    it("should pass in the correct arguments", function() {
-      ComponentClass = generateParentComponentClass({
-        children: children,
-        render: function() {
-          return this.loadChild('myChild', 'bar', 'baz');
+    it("should ref from .children function when specified", function() {
+      componentClassSpec.children = {
+        son: function() {
+          return {
+            component: 'Child',
+            ref: 'junior'
+          };
         }
-      });
-      componentElement = React.createElement(ComponentClass);
-      componentInstance = utils.renderIntoDocument(componentElement);
+      };
 
-      expect(childSpy).toHaveBeenCalledWith('bar', 'baz');
+      renderComponent();
+      componentInstance.loadChild('son');
+
+      var createElementProps = Cosmos.createElement.calls.mostRecent().args[0];
+      expect(createElementProps.ref).toBe('junior');
     });
 
-    it("should set the correct ref when it is passed in", function() {
-      ComponentClass = generateParentComponentClass({
-        children: children,
-        render: function() {
-          return this.loadChild('myChild', 'customChildRef', 'baz');
+    it("should pass on component lookup to children", function() {
+      componentClassSpec.children = {
+        son: function() {
+          return {};
         }
-      });
-      componentElement = React.createElement(ComponentClass);
-      componentInstance = utils.renderIntoDocument(componentElement);
+      };
 
-      expect(Cosmos.createElement).toHaveBeenCalledWith({
-        foo: 'bar',
-        ref: 'customChildRef'
-      });
+      var gimmeComponents = function() {};
+      componentProps = {
+        componentLookup: gimmeComponents
+      };
+
+      renderComponent();
+      componentInstance.loadChild('son');
+
+      var createElementProps = Cosmos.createElement.calls.mostRecent().args[0];
+      expect(createElementProps.componentLookup).toBe(gimmeComponents);
     });
 
-    it("should set the correct ref when it is not passed in", function() {
-      ComponentClass = generateParentComponentClass({
-        children: children,
-        render: function() {
-          return this.loadChild('myChild');
+    it("should pass extra loadChild args to children function", function() {
+      var childSpy = jasmine.createSpy();
+
+      componentClassSpec.children = {
+        son: childSpy
+      };
+
+      renderComponent();
+      componentInstance.loadChild('son', 'one', 'two', 'three');
+
+      expect(childSpy).toHaveBeenCalledWith('one', 'two', 'three');
+    });
+  });
+
+  describe("loading missing children", function() {
+
+    beforeEach(function() {
+      spyOn(Cosmos, 'createElement').and.callFake(function() {
+        throw new Error('Invalid component');
+      });
+
+      spyOn(console, 'error');
+
+      componentClassSpec.children ={
+        son: function() {
+          return {
+            component: 'MissingChild'
+          };
+        }
+      };
+    });
+
+    it("should not throw error", function() {
+      var whereAreYouSon = function() {
+        renderComponent();
+        componentInstance.loadChild('son');
+      };
+
+      expect(whereAreYouSon).not.toThrow();
+    });
+
+    it("should call console.error", function() {
+      renderComponent();
+      componentInstance.loadChild('son');
+
+      var error = new Error('Invalid component');
+      expect(console.error).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe("injecting state", function() {
+
+    beforeEach(function() {
+      spyOn(Cosmos, 'createElement');
+    });
+
+    it("should load their state from the state prop", function() {
+      componentProps.state = {
+        mood: 'indiferent',
+        nevermind: true
+      };
+
+      renderComponent();
+
+      expect(componentInstance.state.mood).toBe('indiferent');
+      expect(componentInstance.state.nevermind).toBe(true);
+    });
+
+    it("should replace their state from the state prop", function() {
+      renderComponent();
+
+      componentInstance.setState({
+        mood: 'indiferent',
+        nevermind: true
+      });
+
+      componentInstance.setProps({
+        state: {
+          mood: 'interested'
         }
       });
-      componentElement = React.createElement(ComponentClass);
-      componentInstance = utils.renderIntoDocument(componentElement);
 
-      expect(Cosmos.createElement).toHaveBeenCalledWith({
-        foo: 'bar',
-        ref: 'myChild'
+      expect(componentInstance.state.mood).toBe('interested');
+      expect(componentInstance.state.nevermind).toBe(undefined);
+    });
+
+    it("should extend received state with initial state", function() {
+      componentClassSpec.getInitialState = function() {
+        return {
+          always: 'curious'
+        };
+      };
+
+      componentProps.state = {
+        mood: 'indiferent'
+      };
+
+      renderComponent();
+
+      expect(componentInstance.state.mood).toBe('indiferent');
+      expect(componentInstance.state.always).toBe('curious');
+    });
+
+    describe("recursively", function() {
+
+      beforeEach(function() {
+        componentClassSpec.children = {
+          son: function() {
+            return {};
+          }
+        };
+        componentClassSpec.render = function() {
+          return React.DOM.div({}, this.loadChild('son'));
+        };
+
+        componentProps.state = {
+          children: {
+            son: {
+              witty: true
+            }
+          }
+        };
       });
+
+      it("should inject state into children recursively", function() {
+        renderComponent();
+
+        var createElementProps = Cosmos.createElement.calls.mostRecent().args[0];
+        expect(createElementProps.state.witty).toBe(true);
+      });
+
+      it("shouldn't send state to children after the first time", function() {
+        renderComponent();
+        componentInstance.forceUpdate();
+
+        var createElementProps = Cosmos.createElement.calls.mostRecent().args[0];
+        expect(createElementProps.state).toBe(undefined);
+      });
+    });
+  });
+
+  describe("serializing", function() {
+
+    beforeEach(function() {
+      spyOn(Cosmos, 'createElement');
+    });
+
+    it("should generate snapshot with props", function() {
+      renderComponent();
+      componentInstance.setProps({
+        players: 5
+      });
+
+      var snapshot = componentInstance.serialize();
+      expect(snapshot.players).toBe(5);
+    });
+
+    it("should generate snapshot with state", function() {
+      renderComponent();
+      componentInstance.setState({
+        speed: 1
+      });
+
+      var snapshot = componentInstance.serialize();
+      expect(snapshot.state.speed).toBe(1);
+    });
+
+    it("should generate snapshot with nested child state", function() {
+      componentClassSpec.children = {
+        son: function() {
+          return {};
+        }
+      };
+
+      renderComponent();
+
+      // Fake a child instance with a serialize implementation
+      componentInstance.refs = {
+        son: {
+          serialize: function() {
+            return {
+              component: 'Child',
+              state: {
+                age: 5
+              }
+            };
+          }
+        }
+      };
+
+      var snapshot = componentInstance.serialize(true);
+      expect(snapshot.state.children.son.age).toBe(5);
     });
   });
 });

--- a/specs/mixins/url-spec.js
+++ b/specs/mixins/url-spec.js
@@ -51,7 +51,7 @@ describe("Components implementing the Url mixin", function() {
     });
     componentInstance = utils.renderIntoDocument(componentElement);
 
-    expect(componentInstance.getUrlFromProps(componentInstance.generateSnapshot()))
+    expect(componentInstance.getUrlFromProps(componentInstance.serialize()))
           // state=encodeURIComponent(JSON.stringify({speed:1}))
           .toEqual('?players=5&state=%7B%22speed%22%3A1%7D');
 

--- a/specs/mixins/url-spec.js
+++ b/specs/mixins/url-spec.js
@@ -25,7 +25,7 @@ describe("Components implementing the Url mixin", function() {
   // generated for every test case
   var generateComponentClass = function(attributes) {
     return React.createClass(_.extend({}, {
-      mixins: [Cosmos.mixins.PersistState,
+      mixins: [Cosmos.mixins.ComponentTree,
                Cosmos.mixins.Url],
       render: function() {
         return React.DOM.span();


### PR DESCRIPTION
- [x] No longer deep clone anything
- [x] No longer alter props!
- [x] No longer clear childProps cache inside a getter!
  - [x] Do it on `componentDidUpdate` and `componentDidMount`
    - [x] Think about when shouldComponentUpdate returns false
- [x] Extend getInitialState when overriding state from snapshot
- [x] Name and order private methods accordingly
- [x] Refactor and improve style of unit tests (so hard :cry:)
- [x] Find a better name
  - [x] `ComponentTree`

Part 2:

- [x] No longer inject state on props
- [x] Update Docstring
- [x] Update Mixins wiki page
- [x] Process loadChild arguments without leaks
- New specs
  - [x] Inject state with custom refs
  - [x] ~~Serialize with custom refs~~ No need, serializing [always worked with refs directly](https://github.com/skidding/cosmos/blob/301a14b8f0ae25fa2516e66ada3d7776bc4ee0fc/mixins/persist-state.js#L37)