### PR TITLE
Remove key from Router

### DIFF
--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -24,6 +24,56 @@ module.exports = React.createClass({
     containerClassName: React.PropTypes.string
   },
 
+  statics: {
+    getInitialState: function(fixtures, fixturePath) {
+      return {
+        expandedComponents: this.getExpandedComponents(fixturePath),
+        fixtureContents: this.getFixtureContents(fixtures, fixturePath),
+        fixtureUserInput: this.getFixtureUserInput(fixtures, fixturePath),
+        isFixtureUserInputValid: true
+      };
+    },
+
+    getExpandedComponents: function(fixturePath) {
+      var components = [];
+
+      // Expand the relevant component when a fixture is selected
+      if (fixturePath) {
+        components.push(this.getComponentName(fixturePath));
+      }
+
+      return components;
+    },
+
+    getFixtureUserInput: function(fixtures, fixturePath) {
+      if (!fixturePath) {
+        return '';
+      }
+
+      var contents = this.getFixtureContents(fixtures, fixturePath);
+      return JSON.stringify(contents, null, 2);
+    },
+
+    getFixtureContents: function(fixtures, fixturePath) {
+      if (!fixturePath) {
+        return null;
+      }
+
+      var componentName = this.getComponentName(fixturePath),
+          fixtureName = this.getFixtureName(fixturePath);
+
+      return fixtures[componentName][fixtureName];
+    },
+
+    getComponentName: function(fixturePath) {
+      return fixturePath.split('/')[0];
+    },
+
+    getFixtureName: function(fixturePath) {
+      return fixturePath.substr(fixturePath.indexOf('/') + 1);
+    }
+  },
+
   getDefaultProps: function() {
     return {
       fixtureEditor: false,
@@ -32,12 +82,8 @@ module.exports = React.createClass({
   },
 
   getInitialState: function() {
-    return {
-      expandedComponents: this._getInitialExpandedComponents(),
-      fixtureContents: this._getInitialFixtureContents(),
-      fixtureUserInput: this._getInitialFixtureUserInput(),
-      isFixtureUserInputValid: true
-    };
+    return this.constructor.getInitialState(this.props.fixtures,
+                                            this.props.fixturePath);
   },
 
   children: {
@@ -45,7 +91,7 @@ module.exports = React.createClass({
       var fixturePath = this.props.fixturePath;
 
       var props = {
-        component: this._getComponentNameFromPath(fixturePath),
+        component: this.constructor.getComponentName(fixturePath),
         // Child should re-render whenever fixture changes
         key: JSON.stringify(this.state.fixtureContents)
       };
@@ -232,34 +278,6 @@ module.exports = React.createClass({
     this.setState(newState);
   },
 
-  _getInitialExpandedComponents: function() {
-    var components = [];
-
-    // Expand the relevant component when a fixture is selected
-    if (this.props.fixturePath) {
-      components.push(this._getComponentNameFromPath(this.props.fixturePath));
-    }
-
-    return components;
-  },
-
-  _getInitialFixtureContents: function() {
-    if (!this.props.fixturePath) {
-      return null;
-    }
-
-    return this._getFixtureContentsFromPath(this.props.fixturePath);
-  },
-
-  _getInitialFixtureUserInput: function() {
-    if (!this.props.fixturePath) {
-      return '';
-    }
-
-    var contents = this._getFixtureContentsFromPath(this.props.fixturePath);
-    return JSON.stringify(contents, null, 2);
-  },
-
   _getPreviewClasses: function() {
     var classes = {
       'preview': true,
@@ -280,27 +298,14 @@ module.exports = React.createClass({
 
     var fixturePath = this.props.fixturePath;
     if (fixturePath) {
-      var selectedComponentName = this._getComponentNameFromPath(fixturePath),
-          selectedFixtureName = this._getFixtureNameFromPath(fixturePath);
+      var selectedComponentName =
+              this.constructor.getComponentName(fixturePath),
+          selectedFixtureName = this.constructor.getFixtureName(fixturePath);
+
       classes['selected'] = componentName === selectedComponentName &&
                             fixtureName === selectedFixtureName;
     }
 
     return classSet(classes);
-  },
-
-  _getFixtureContentsFromPath: function(fixturePath) {
-    var componentName = this._getComponentNameFromPath(fixturePath),
-        fixtureName = this._getFixtureNameFromPath(fixturePath);
-
-    return this.props.fixtures[componentName][fixtureName];
-  },
-
-  _getComponentNameFromPath: function(fixturePath) {
-    return fixturePath.split('/')[0];
-  },
-
-  _getFixtureNameFromPath: function(fixturePath) {
-    return fixturePath.substr(fixturePath.indexOf('/') + 1);
   }
 });

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -246,6 +246,13 @@ module.exports = React.createClass({
     </li>;
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    if (nextProps.fixturePath !== this.props.fixturePath) {
+      this.setState(this.constructor.getInitialState(nextProps.fixtures,
+                                                     nextProps.fixturePath));
+    }
+  },
+
   onComponentClick: function(componentName, event) {
     event.preventDefault();
 

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -202,7 +202,7 @@ module.exports = React.createClass({
     return <div className="fixture-editor-outer">
       <textarea ref="fixtureEditor"
                 className={editorClasses}
-                defaultValue={this.state.fixtureUserInput}
+                value={this.state.fixtureUserInput}
                 onChange={this.onFixtureChange}>
       </textarea>
     </div>;

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -62,13 +62,7 @@ Router.prototype = {
       // Always send the components a reference to the router. This makes it
       // possible for a component to change the page through the router and
       // not have to rely on any sort of globals
-      router: this,
-      // Use the href as an identifier for the component. This is useful when
-      // browsing between more instances of the same component after the
-      // router cached state for each. Without the unique key prop the
-      // component would be updated through componentWillReceiveProps and the
-      // cached state would be ignored
-      key: href
+      router: this
     };
     var props = _.extend(baseProps, this._options.defaultProps, newProps);
 

--- a/tests/components/component-playground/state.js
+++ b/tests/components/component-playground/state.js
@@ -24,7 +24,11 @@ describe('ComponentPlayground component', function() {
     // Allow tests to extend the base fixture
     props = {
       fixtures: {
-        FirstComponent: {},
+        FirstComponent: {
+          'blank-state': {
+            myProp: false
+          }
+        },
         SecondComponent: {
           'simple-state': {
             myProp: true
@@ -71,6 +75,55 @@ describe('ComponentPlayground component', function() {
       var fixtureContents = component.state.fixtureContents;
       expect(component.state.fixtureUserInput)
             .to.equal(JSON.stringify(fixtureContents, null, 2));
+    });
+
+    describe('on fixture transition', function() {
+      it('should reset expanded components', function() {
+        render({
+          fixturePath: 'SecondComponent/simple-state'
+        });
+
+        component.setProps({fixturePath: 'FirstComponent/blank-state'});
+
+        expect(component.state.expandedComponents.length).to.equal(1);
+        expect(component.state.expandedComponents[0])
+              .to.equal('FirstComponent');
+      });
+
+      it('should reset fixture contents', function() {
+        render({
+          fixturePath: 'SecondComponent/simple-state'
+        });
+
+        component.setProps({fixturePath: 'FirstComponent/blank-state'});
+
+        expect(component.state.fixtureContents.myProp).to.equal(false);
+      });
+
+      it('should reset fixture user input', function() {
+        render({
+          fixturePath: 'SecondComponent/simple-state'
+        });
+
+        component.setProps({fixturePath: 'FirstComponent/blank-state'});
+
+        var fixtureContents = props.fixtures.FirstComponent['blank-state'];
+        expect(component.state.fixtureUserInput)
+              .to.equal(JSON.stringify(fixtureContents, null, 2));
+      });
+
+      it('should reset valid user input flag', function() {
+        render({
+          fixturePath: 'SecondComponent/simple-state',
+          state: {
+            isFixtureUserInputValid: false
+          }
+        });
+
+        component.setProps({fixturePath: 'FirstComponent/blank-state'});
+
+        expect(component.state.isFixtureUserInputValid).to.be.true;
+      });
     });
   });
 });

--- a/tests/lib/router/router.js
+++ b/tests/lib/router/router.js
@@ -64,13 +64,6 @@ describe('Router class', function() {
       expect(propsSent.router).to.equal(routerInstance);
     });
 
-    it('should set key to current window location href', function() {
-      new Router({onRender: onRenderSpy});
-
-      var propsSent = onRenderSpy.lastCall.args[0];
-      expect(propsSent.key).to.equal(window.location.href);
-    });
-
     it('should default to document.body as container', function() {
       new Router({onRender: onRenderSpy});
 
@@ -192,16 +185,6 @@ describe('Router class', function() {
 
       var propsSent = onRenderSpy.lastCall.args[0];
       expect(propsSent.router).to.equal(router);
-    });
-
-    it('should set key to sent href value', function() {
-      var router = new Router({onRender: onRenderSpy});
-
-      router.goTo('my-page?component=User&dataUrl=user.json');
-
-      var propsSent = onRenderSpy.lastCall.args[0];
-      expect(propsSent.key)
-            .to.equal('my-page?component=User&dataUrl=user.json');
     });
 
     it('should push new props to browser history', function() {
@@ -329,17 +312,6 @@ describe('Router class', function() {
 
       var propsSent = onRenderSpy.lastCall.args[0];
       expect(propsSent.router).to.equal(router);
-    });
-
-    it('should set key to current window location href', function() {
-      var router = new Router({onRender: onRenderSpy});
-
-      router.onPopState({
-        state: {}
-      });
-
-      var propsSent = onRenderSpy.lastCall.args[0];
-      expect(propsSent.key).to.equal(window.location.href);
     });
 
     it('should call onChange callback', function() {


### PR DESCRIPTION
Allow router to reuse components and DOM between pages.

- [x] Remove key from Router
- [x] Enhance ComponentPlayground to transition from one fixture to another
- [x] Textarea must use value instead of defaultValue

### State tests

- on fixture change
  - [x] should reset expanded components 
  - [x] should reset fixture contents
  - [x] should reset fixture user input
  - [x] should reset valid user input flag