### PR TITLE
Improve style of Component Playground

### DIFF
--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -146,9 +146,10 @@ module.exports = React.createClass({
 
         return <li className={classes} key={componentName}>
           <p className="component-name">
-            <a href="#toggle-component"
-               onClick={_.partial(this.onComponentClick, componentName)}
-               ref={componentName + 'Button'}>
+            <a ref={componentName + 'Button'}
+               href="#toggle-component"
+               title={componentName}
+               onClick={_.partial(this.onComponentClick, componentName)}>
               {componentName}
             </a>
           </p>
@@ -173,6 +174,7 @@ module.exports = React.createClass({
                                                       fixtureName)}
                    key={fixtureName}>
           <a href={this.getUrlFromProps(fixtureProps)}
+             title={fixtureName}
              onClick={this.routeLink}>
             {fixtureName}
           </a>

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -174,7 +174,7 @@ module.exports = React.createClass({
                    key={fixtureName}>
           <a href={this.getUrlFromProps(fixtureProps)}
              onClick={this.routeLink}>
-            {fixtureName.replace(/-/g, ' ')}
+            {fixtureName}
           </a>
         </li>;
 

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -107,8 +107,6 @@ module.exports = React.createClass({
       fixtureEditor: this.props.fixtureEditor
     };
 
-    var isFixtureSelected = this.constructor.isFixtureSelected(this.props);
-
     return (
       <div className={classes}>
         <div className="header">
@@ -119,7 +117,7 @@ module.exports = React.createClass({
                onClick={this.routeLink}>
               <span className="react">React</span> Component Playground
             </a>
-            {!isFixtureSelected ? this._renderCosmosPlug() : null}
+            {!this.state.fixtureContents ? this._renderCosmosPlug() : null}
           </h1>
         </div>
         <div className="fixtures">

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -120,10 +120,7 @@ module.exports = React.createClass({
                onClick={this.routeLink}>
               <span className="react">React</span> Component Playground
             </a>
-            <span className="cosmos-plug">
-              {'powered by '}
-              <a href="https://github.com/skidding/cosmos">Cosmos</a>
-            </span>
+            {!this.props.fixturePath ? this._renderCosmosPlug() : null}
           </h1>
         </div>
         <div className="fixtures">
@@ -132,6 +129,13 @@ module.exports = React.createClass({
         {this._renderContentFrame()}
       </div>
     );
+  },
+
+  _renderCosmosPlug: function() {
+    return <span ref="cosmosPlug" className="cosmos-plug">
+      {'powered by '}
+      <a href="https://github.com/skidding/cosmos">Cosmos</a>
+    </span>;
   },
 
   _renderFixtures: function() {

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -283,7 +283,7 @@ module.exports = React.createClass({
         newState = {fixtureUserInput: userInput};
 
     try {
-      newState.fixtureContents = JSON.parse(userInput);
+      newState.fixtureContents = userInput ? JSON.parse(userInput) : null;
       newState.isFixtureUserInputValid = true;
     } catch (e) {
       newState.isFixtureUserInputValid = false;

--- a/components/component-playground.less
+++ b/components/component-playground.less
@@ -32,7 +32,7 @@
       .cosmos-plug {
         margin-left: 10px;
         color: #aaa;
-        font-size: 18px;
+        font-weight: 300;
 
         a {
           color: #cc7a6f;

--- a/components/component-playground.less
+++ b/components/component-playground.less
@@ -168,13 +168,15 @@
       bottom: 0;
       left: 0;
       right: 50%;
+      padding: 10px;
+      border: 1px solid rgba(16, 16, 16, 0.1);
+      background: #f8f5ec;
 
       .fixture-editor {
         width: 100%;
         height: 100%;
-        padding: 10px;
-        border: 1px solid rgba(16, 16, 16, 0.1);
-        background: #f8f5ec;
+        border: none;
+        background: transparent;
         color: #637c84;
         font-family: Menlo, Consolas, 'Courier New', monospace;
         font-size: 13px;

--- a/components/component-playground.less
+++ b/components/component-playground.less
@@ -5,7 +5,7 @@
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
 
-  .header {
+  > .header {
     position: absolute;
     top: 0;
     left: 0;
@@ -75,7 +75,7 @@
     }
   }
 
-  .fixtures {
+  > .fixtures {
     position: absolute;
     top: 50px;
     bottom: 0;
@@ -155,7 +155,7 @@
     }
   }
 
-  .content-frame {
+  > .content-frame {
     position: absolute;
     top: 50px;
     bottom: 0;

--- a/components/component-playground.less
+++ b/components/component-playground.less
@@ -104,6 +104,9 @@
             font-size: 16px;
             line-height: 50px;
             text-decoration: none;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
 
             &:hover {
               color: #fafafa;
@@ -130,6 +133,9 @@
               color: #c05b4d;
               line-height: 30px;
               text-decoration: none;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
 
               &:hover {
                 background: rgba(0, 0, 0, 0.05);

--- a/examples/component-playground/component-playground.html
+++ b/examples/component-playground/component-playground.html
@@ -23,59 +23,59 @@ html, body {
 // The Component Playground inside itself might not be the best example :)
 var fixtures = {
   ComponentPlayground: {
-    'without-fixture-selected': {
+    'without fixture selected': {
       fixtures: {
         ComponentPlayground: {
-          'without-fixture-selected': {},
-          'with-fixture-selected': {}
+          'without fixture selected': {},
+          'with fixture selected': {}
         }
       }
     },
-    'with-expanded-component': {
+    'with expanded component': {
       fixtures: {
         ComponentPlayground: {
-          'without-fixture-selected': {},
-          'with-fixture-selected': {}
+          'without fixture selected': {},
+          'with fixture selected': {}
         }
       },
       state: {
         expandedComponents: ['ComponentPlayground']
       }
     },
-    'with-fixture-selected': {
+    'with fixture selected': {
       fixtures: {
         ComponentPlayground: {
-          'without-fixture-selected': {},
-          'with-fixture-selected': {}
+          'without fixture selected': {},
+          'with fixture selected': {}
         }
       },
       selectedComponent: 'ComponentPlayground',
-      selectedFixture: 'with-fixture-selected'
+      selectedFixture: 'with fixture selected'
     },
-    'with-fixture-editor-open': {
+    'with fixture editor-open': {
       fixtures: {
         ComponentPlayground: {
-          'only-fixture': {
+          'only fixture': {
             fixtures: {
               ComponentPlayground: {
-                'recurring-fixture': {}
+                'recurring fixture': {}
               }
             }
           }
         }
       },
       selectedComponent: 'ComponentPlayground',
-      selectedFixture: 'only-fixture',
+      selectedFixture: 'only fixture',
       fixtureEditor: true
     },
     'full-screen': {
       fixtures: {
         ComponentPlayground: {
-          'only-fixture': {}
+          'only fixture': {}
         }
       },
       selectedComponent: 'ComponentPlayground',
-      selectedFixture: 'only-fixture',
+      selectedFixture: 'only fixture',
       fullScreen: true
     }
   }

--- a/tests/components/component-playground/children.js
+++ b/tests/components/component-playground/children.js
@@ -87,11 +87,9 @@ describe('ComponentPlayground component', function() {
         var obj = {};
 
         render({
-          fixtures: {
-            MyComponent: {
-              'small size': {
-                shouldBeCloned: obj
-              }
+          state: {
+            fixtureContents: {
+              shouldBeCloned: obj
             }
           }
         });

--- a/tests/components/component-playground/children.js
+++ b/tests/components/component-playground/children.js
@@ -89,7 +89,7 @@ describe('ComponentPlayground component', function() {
         render({
           fixtures: {
             MyComponent: {
-              'small-size': {
+              'small size': {
                 shouldBeCloned: obj
               }
             }

--- a/tests/components/component-playground/events.js
+++ b/tests/components/component-playground/events.js
@@ -125,6 +125,12 @@ describe('ComponentPlayground component', function() {
                .to.equal(initialFixtureContents.myProp);
       });
 
+      it('should empty fixture contents on empty input', function() {
+        triggerChange('');
+
+        expect(component.state.fixtureContents).to.equal(null);
+      });
+
       it('should call console.error on invalid change', function() {
         triggerChange('lorem ipsum');
 

--- a/tests/components/component-playground/events.js
+++ b/tests/components/component-playground/events.js
@@ -42,7 +42,7 @@ describe('ComponentPlayground component', function() {
         props.fixtures = {
           FirstComponent: {},
           SecondComponent: {
-            'simple-state': {}
+            'simple state': {}
           }
         };
       });

--- a/tests/components/component-playground/render.js
+++ b/tests/components/component-playground/render.js
@@ -32,12 +32,12 @@ describe('ComponentPlayground component', function() {
     props = {
       fixtures: {
         FirstComponent: {
-          'blank-state': {},
-          'error-state': {},
-          'simple-state': {}
+          'blank state': {},
+          'error state': {},
+          'simple state': {}
         },
         SecondComponent: {
-          'simple-state': {}
+          'simple state': {}
         }
       }
     };
@@ -98,9 +98,9 @@ describe('ComponentPlayground component', function() {
           $component2 = $component.find('.component:eq(1)');
 
       expect($component1.find('.component-fixtures li:first').text())
-            .to.equal('blank-state');
+            .to.equal('blank state');
       expect($component2.find('.component-fixtures li:first').text())
-            .to.equal('simple-state');
+            .to.equal('simple state');
     });
 
     it('should generate url with fixture path', function() {
@@ -110,7 +110,7 @@ describe('ComponentPlayground component', function() {
           urlProps = getUrlProps(firstFixtureLink);
 
       expect(urlProps.selectedComponent).to.equal('FirstComponent');
-      expect(urlProps.selectedFixture).to.equal('blank-state');
+      expect(urlProps.selectedFixture).to.equal('blank state');
     });
 
     it('should not add full-screen class when prop is false', function() {
@@ -166,7 +166,7 @@ describe('ComponentPlayground component', function() {
       beforeEach(function() {
         _.extend(props, {
           selectedComponent: 'FirstComponent',
-          selectedFixture: 'simple-state'
+          selectedFixture: 'simple state'
         })
       });
 
@@ -196,7 +196,7 @@ describe('ComponentPlayground component', function() {
             urlProps = getUrlProps(element);
 
         expect(urlProps.selectedComponent).to.equal('FirstComponent');
-        expect(urlProps.selectedFixture).to.equal('simple-state');
+        expect(urlProps.selectedFixture).to.equal('simple state');
         expect(urlProps.fullScreen).to.equal(true);
       });
 
@@ -208,7 +208,7 @@ describe('ComponentPlayground component', function() {
             urlProps = getUrlProps(element);
 
         expect(urlProps.selectedComponent).to.equal('FirstComponent');
-        expect(urlProps.selectedFixture).to.equal('simple-state');
+        expect(urlProps.selectedFixture).to.equal('simple state');
         expect(urlProps.fixtureEditor).to.equal(true);
       });
     });
@@ -264,7 +264,7 @@ describe('ComponentPlayground component', function() {
             urlProps = getUrlProps(firstFixtureLink);
 
         expect(urlProps.selectedComponent).to.equal('FirstComponent');
-        expect(urlProps.selectedFixture).to.equal('blank-state');
+        expect(urlProps.selectedFixture).to.equal('blank state');
         expect(urlProps.fixtureEditor).to.equal(true);
       });
 
@@ -284,7 +284,7 @@ describe('ComponentPlayground component', function() {
     it('should generate url for closing editor with fixture', function() {
       render({
         selectedComponent: 'FirstComponent',
-        selectedFixture: 'simple-state',
+        selectedFixture: 'simple state',
         fixtureEditor: true
       });
 
@@ -292,7 +292,7 @@ describe('ComponentPlayground component', function() {
           urlProps = getUrlProps(element);
 
       expect(urlProps.selectedComponent).to.equal('FirstComponent');
-      expect(urlProps.selectedFixture).to.equal('simple-state');
+      expect(urlProps.selectedFixture).to.equal('simple state');
       expect(urlProps.fixtureEditor).to.equal(false);
     });
   });

--- a/tests/components/component-playground/render.js
+++ b/tests/components/component-playground/render.js
@@ -91,16 +91,16 @@ describe('ComponentPlayground component', function() {
       expect($component2.find('.component-fixtures li').length).to.equal(1);
     });
 
-    it('should add spaces from hypens in fixture names', function() {
+    it('should render fixture names', function() {
       render();
 
       var $component1 = $component.find('.component:eq(0)'),
           $component2 = $component.find('.component:eq(1)');
 
       expect($component1.find('.component-fixtures li:first').text())
-            .to.equal('blank state');
+            .to.equal('blank-state');
       expect($component2.find('.component-fixtures li:first').text())
-            .to.equal('simple state');
+            .to.equal('simple-state');
     });
 
     it('should generate url with fixture path', function() {

--- a/tests/components/component-playground/render.js
+++ b/tests/components/component-playground/render.js
@@ -157,9 +157,21 @@ describe('ComponentPlayground component', function() {
       expect(component.refs.fixtureEditor).to.not.exist;
     });
 
+    it('should render cosmos plug by default', function() {
+      render();
+
+      expect(component.refs.cosmosPlug).to.exist;
+    });
+
     describe('with fixture path selected', function() {
       beforeEach(function() {
         props.fixturePath = 'SecondComponent/simple-state';
+      });
+
+      it('should not render cosmos plug', function() {
+        render();
+
+        expect(component.refs.cosmosPlug).to.not.exist;
       });
 
       it('should generate full-screen url', function() {

--- a/tests/components/component-playground/render.js
+++ b/tests/components/component-playground/render.js
@@ -54,6 +54,16 @@ describe('ComponentPlayground component', function() {
       expect(component.refs.cosmosPlug).to.exist;
     });
 
+    it('should not render cosmos plug with preview loaded', function() {
+      render({
+        state: {
+          fixtureContents: {}
+        }
+      });
+
+      expect(component.refs.cosmosPlug).to.not.exist;
+    });
+
     it('should render each component', function() {
       render();
 
@@ -158,12 +168,6 @@ describe('ComponentPlayground component', function() {
           selectedComponent: 'FirstComponent',
           selectedFixture: 'simple-state'
         })
-      });
-
-      it('should not render cosmos plug', function() {
-        render();
-
-        expect(component.refs.cosmosPlug).to.not.exist;
       });
 
       it('should add expanded class to selected component', function() {

--- a/tests/components/component-playground/state.js
+++ b/tests/components/component-playground/state.js
@@ -24,12 +24,12 @@ describe('ComponentPlayground component', function() {
     props = {
       fixtures: {
         FirstComponent: {
-          'blank-state': {
+          'blank state': {
             myProp: false
           }
         },
         SecondComponent: {
-          'simple-state': {
+          'simple state': {
             myProp: true
           }
         }
@@ -52,7 +52,7 @@ describe('ComponentPlayground component', function() {
       beforeEach(function() {
         _.extend(props, {
           selectedComponent: 'FirstComponent',
-          selectedFixture: 'blank-state'
+          selectedFixture: 'blank state'
         });
       });
 
@@ -91,7 +91,7 @@ describe('ComponentPlayground component', function() {
 
           component.setProps({
             selectedComponent: 'SecondComponent',
-            selectedFixture: 'simple-state'
+            selectedFixture: 'simple state'
           });
         });
 
@@ -108,7 +108,7 @@ describe('ComponentPlayground component', function() {
         });
 
         it('should reset fixture user input', function() {
-          var fixtureContents = props.fixtures.FirstComponent['blank-state'];
+          var fixtureContents = props.fixtures.FirstComponent['blank state'];
 
           expect(JSON.parse(component.state.fixtureUserInput).myProp)
                 .to.equal(true);


### PR DESCRIPTION
- [x] Fix padding inside fixture editor
- [x] Prevent styles from propagating to loaded children
- [x] Hide Cosmos plug when fixture is selected
- [x] Support multi-line component names and fixture names
  - [x] Add title to component and fixture
  - [x] Add `text-overflow: ellipsis`, `overflow:hidden` and `white-space:nowrap` to component and fixture
- [x] ~~Replace hyphens with spaces in component names~~ < The opposite