### PR TITLE
Separate component and fixture from fixturePath

### DIFF
--- a/examples/component-playground/component-playground.html
+++ b/examples/component-playground/component-playground.html
@@ -49,7 +49,8 @@ var fixtures = {
           'with-fixture-selected': {}
         }
       },
-      fixturePath: 'ComponentPlayground/with-fixture-selected'
+      selectedComponent: 'ComponentPlayground',
+      selectedFixture: 'with-fixture-selected'
     },
     'with-fixture-editor-open': {
       fixtures: {
@@ -63,7 +64,8 @@ var fixtures = {
           }
         }
       },
-      fixturePath: 'ComponentPlayground/only-fixture',
+      selectedComponent: 'ComponentPlayground',
+      selectedFixture: 'only-fixture',
       fixtureEditor: true
     },
     'full-screen': {
@@ -72,7 +74,8 @@ var fixtures = {
           'only-fixture': {}
         }
       },
-      fixturePath: 'ComponentPlayground/only-fixture',
+      selectedComponent: 'ComponentPlayground',
+      selectedFixture: 'only-fixture',
       fullScreen: true
     }
   }
@@ -89,8 +92,10 @@ var router = Cosmos.start({
     var title = 'React Component Playground';
 
     // Set document title to the name of the selected fixture
-    if (props.fixturePath) {
-      title = props.fixturePath + ' – ' + title;
+    if (props.selectedComponent && props.selectedFixture) {
+      title = props.selectedComponent + ':' +
+              props.selectedFixture + ' – ' +
+              title;
     }
 
     document.title = title;

--- a/tests/components/component-playground/children.js
+++ b/tests/components/component-playground/children.js
@@ -10,8 +10,8 @@ describe('ComponentPlayground component', function() {
       props,
       childProps;
 
-  // Alow tests to extend fixture before rendering
   function render(extraProps) {
+    // Alow tests to extend fixture before rendering
     _.merge(props, extraProps);
 
     component = renderComponent(ComponentPlayground, props);
@@ -26,17 +26,8 @@ describe('ComponentPlayground component', function() {
     // Don't render any children
     sinon.stub(Cosmos, 'createElement');
 
-    // Allow tests to extend the base fixture
     props = {
-      fixtures: {
-        MyComponent: {
-          'small-size': {
-            width: 200,
-            height: 100
-          }
-        }
-      },
-      fixturePath: 'MyComponent/small-size'
+      fixtures: {}
     };
   });
 
@@ -45,58 +36,68 @@ describe('ComponentPlayground component', function() {
   })
 
   describe('children', function() {
-    it('should not render child if no fixture is selected', function() {
-      delete props.fixturePath;
-
+    it('should not render child without fixture contents', function() {
       render();
 
       expect(Cosmos.createElement).to.not.have.been.called;
     });
 
-    it('should send down component name to preview child', function() {
-      render();
-
-      expect(childProps.component).to.equal('MyComponent');
-    });
-
-    it('should send fixture contents to preview child', function() {
-      render();
-
-      var fixtureContents = component.state.fixtureContents;
-      expect(childProps.width).to.equal(fixtureContents.width);
-      expect(childProps.height).to.equal(fixtureContents.height);
-    });
-
-    it('should send (Cosmos) router instance to preview child', function() {
-      render({
-        router: {}
-      });
-
-      expect(childProps.router).to.equal(props.router);
-    });
-
-    it('should use fixture contents as key for preview child', function() {
-      render();
-
-      var fixtureContents = component.state.fixtureContents,
-          stringifiedFixtureContents = JSON.stringify(fixtureContents);
-      expect(childProps.key).to.equal(stringifiedFixtureContents);
-    });
-
-    it('should clone fixture contents sent to child', function() {
-      var obj = {};
-
-      render({
-        fixtures: {
-          MyComponent: {
-            'small-size': {
-              shouldBeCloned: obj
+    describe('with fixture contents', function() {
+      beforeEach(function() {
+        _.extend(props, {
+          // Children draw their props from state.fixtureContents. Generating
+          // state from props is tested in the state.js suite
+          state: {
+            fixtureContents: {
+              component: 'MyComponent',
+              width: 200,
+              height: 100
             }
           }
-        }
+        });
       });
 
-      expect(childProps.shouldBeCloned).to.not.equal(obj);
+      it('should send fixture contents to preview child', function() {
+        render();
+
+        var fixtureContents = component.state.fixtureContents;
+        expect(childProps.component).to.equal(fixtureContents.component);
+        expect(childProps.width).to.equal(fixtureContents.width);
+        expect(childProps.height).to.equal(fixtureContents.height);
+      });
+
+      it('should send (Cosmos) router instance to preview child', function() {
+        render({
+          router: {}
+        });
+
+        expect(childProps.router).to.equal(props.router);
+      });
+
+      it('should use fixture contents as key for preview child', function() {
+        render();
+
+        var fixtureContents = component.state.fixtureContents,
+            stringifiedFixtureContents = JSON.stringify(fixtureContents);
+
+        expect(childProps.key).to.equal(stringifiedFixtureContents);
+      });
+
+      it('should clone fixture contents sent to child', function() {
+        var obj = {};
+
+        render({
+          fixtures: {
+            MyComponent: {
+              'small-size': {
+                shouldBeCloned: obj
+              }
+            }
+          }
+        });
+
+        expect(childProps.shouldBeCloned).to.not.equal(obj);
+      });
     });
   });
 });

--- a/tests/components/component-playground/events.js
+++ b/tests/components/component-playground/events.js
@@ -11,8 +11,8 @@ describe('ComponentPlayground component', function() {
       $component,
       props;
 
-  // Alow tests to extend fixture before rendering
   function render(extraProps) {
+    // Alow tests to extend fixture before rendering
     _.merge(props, extraProps);
 
     component = renderComponent(ComponentPlayground, props);
@@ -25,14 +25,8 @@ describe('ComponentPlayground component', function() {
     // Don't render any children
     sinon.stub(Cosmos, 'createElement');
 
-    // Allow tests to extend the base fixture
     props = {
-      fixtures: {
-        FirstComponent: {},
-        SecondComponent: {
-          'simple-state': {}
-        }
-      }
+      fixtures: {}
     };
   });
 
@@ -43,26 +37,54 @@ describe('ComponentPlayground component', function() {
   })
 
   describe('events', function() {
-    it('should expand component on click', function() {
-      render();
-
-      utils.Simulate.click(component.refs.SecondComponentButton.getDOMNode());
-
-      expect(component.state.expandedComponents.length).to.equal(1);
-      expect(component.state.expandedComponents[0]).to.equal('SecondComponent');
-    });
-
-    it('should contract expanded component on click', function() {
-      render({
-        state: {
-          expandedComponents: ['FirstComponent', 'SecondComponent']
-        }
+    describe('clicking on components', function() {
+      beforeEach(function() {
+        props.fixtures = {
+          FirstComponent: {},
+          SecondComponent: {
+            'simple-state': {}
+          }
+        };
       });
 
-      utils.Simulate.click(component.refs.SecondComponentButton.getDOMNode());
+      it('should expand component on click', function() {
+        render();
 
-      expect(component.state.expandedComponents.length).to.equal(1);
-      expect(component.state.expandedComponents[0]).to.equal('FirstComponent');
+        utils.Simulate.click(component.refs.SecondComponentButton.getDOMNode());
+
+        var expandedComponents = component.state.expandedComponents;
+        expect(expandedComponents.length).to.equal(1);
+        expect(expandedComponents[0]).to.equal('SecondComponent');
+      });
+
+      it('should keep expanding components click', function() {
+        render({
+          state: {
+            expandedComponents: ['FirstComponent']
+          }
+        });
+
+        utils.Simulate.click(component.refs.SecondComponentButton.getDOMNode());
+
+        var expandedComponents = component.state.expandedComponents;
+        expect(expandedComponents.length).to.equal(2);
+        expect(expandedComponents[0]).to.equal('FirstComponent');
+        expect(expandedComponents[1]).to.equal('SecondComponent');
+      });
+
+      it('should contract expanded component on click', function() {
+        render({
+          state: {
+            expandedComponents: ['FirstComponent', 'SecondComponent']
+          }
+        });
+
+        utils.Simulate.click(component.refs.SecondComponentButton.getDOMNode());
+
+        var expandedComponents = component.state.expandedComponents;
+        expect(expandedComponents.length).to.equal(1);
+        expect(expandedComponents[0]).to.equal('FirstComponent');
+      });
     });
 
     describe('editing fixture', function() {

--- a/tests/components/component-playground/render.js
+++ b/tests/components/component-playground/render.js
@@ -1,5 +1,6 @@
 var $ = require('jquery'),
     Cosmos = require('../../../cosmos.js'),
+    serialize = require('../../../lib/serialize.js'),
     renderComponent = require('../../helpers/render-component.js'),
     ComponentPlayground =
       require('../../../components/component-playground.jsx');
@@ -9,19 +10,25 @@ describe('ComponentPlayground component', function() {
       $component,
       props;
 
-  // Alow tests to extend fixture before rendering
   function render(extraProps) {
+    // Alow tests to extend fixture before rendering
     _.merge(props, extraProps);
 
     component = renderComponent(ComponentPlayground, props);
     $component = $(component.getDOMNode());
-  };
+  }
+
+  function getUrlProps(element) {
+    var href = $(element).attr('href');
+
+    // The serialize and router.url libs are already tested
+    return serialize.getPropsFromQueryString(href.substr(1));
+  }
 
   beforeEach(function() {
     // Don't render any children
     sinon.stub(Cosmos, 'createElement');
 
-    // Allow tests to extend the base fixture
     props = {
       fixtures: {
         FirstComponent: {
@@ -80,27 +87,14 @@ describe('ComponentPlayground component', function() {
             .to.equal('simple state');
     });
 
-    it('should add class to expanded components (only)', function() {
-      render({
-        fixturePath: 'FirstComponent/error-state'
-      });
+    it('should generate url with fixture path', function() {
+      render();
 
-      var $expandedComponent = $component.find('.component.expanded');
+      var firstFixtureLink = $component.find('.component-fixture a'),
+          urlProps = getUrlProps(firstFixtureLink);
 
-      expect($expandedComponent.length).to.equal(1);
-      expect($expandedComponent.find('.component-name').text())
-            .to.equal('FirstComponent');
-    });
-
-    it('should add class to selected fixture (only)', function() {
-      render({
-        fixturePath: 'FirstComponent/simple-state'
-      });
-
-      var $selectedFixture = $component.find('.component-fixture.selected');
-
-      expect($selectedFixture.length).to.equal(1);
-      expect($selectedFixture.text()).to.equal('simple state');
+      expect(urlProps.selectedComponent).to.equal('FirstComponent');
+      expect(urlProps.selectedFixture).to.equal('blank-state');
     });
 
     it('should not add full-screen class when prop is false', function() {
@@ -119,26 +113,21 @@ describe('ComponentPlayground component', function() {
       expect($component.hasClass('full-screen')).to.equal(true);
     });
 
-    it('should generate url with fixture path', function() {
-      render();
-
-      var firstHref = $component.find('.component-fixture a').attr('href');
-
-      expect(firstHref).to.equal('?fixturePath=FirstComponent%2Fblank-state');
-    });
-
-    it('should not render full screen button w/out fixture selected',
+    it('should not render full screen button (w/out fixture selected)',
        function() {
       render();
 
       expect(component.refs.fullScreenButton).to.not.exist;
     });
 
-    it('should not render fixture editor button w/out fixture selected',
+    it('should render fixture editor button',
        function() {
       render();
 
-      expect(component.refs.fixtureEditorButton).to.not.exist;
+      var element = component.refs.fixtureEditorButton.getDOMNode(),
+          urlProps = getUrlProps(element);
+
+      expect(urlProps.fixtureEditor).to.equal(true);
     });
 
     it('should add container class on preview element', function() {
@@ -157,100 +146,138 @@ describe('ComponentPlayground component', function() {
       expect(component.refs.fixtureEditor).to.not.exist;
     });
 
-    describe('with fixture path selected', function() {
+    describe('with fixture selected', function() {
       beforeEach(function() {
-        props.fixturePath = 'SecondComponent/simple-state';
+        _.extend(props, {
+          selectedComponent: 'FirstComponent',
+          selectedFixture: 'simple-state'
+        })
+      });
+
+      it('should add expanded class to selected component', function() {
+        render();
+
+        var $expandedComponent = $component.find('.component.expanded');
+
+        expect($expandedComponent.length).to.equal(1);
+        expect($expandedComponent.find('.component-name').text())
+              .to.equal('FirstComponent');
+      });
+
+      it('should add class to selected fixture', function() {
+        render();
+
+        var $selectedFixture = $component.find('.component-fixture.selected');
+
+        expect($selectedFixture.length).to.equal(1);
+        expect($selectedFixture.text()).to.equal('simple state');
       });
 
       it('should generate full-screen url', function() {
         render();
 
-        var href = $(component.refs.fullScreenButton.getDOMNode())
-                   .attr('href');
+        var element = component.refs.fullScreenButton.getDOMNode(),
+            urlProps = getUrlProps(element);
 
-        expect(href).to.equal('?fixturePath=SecondComponent%2Fsimple-state' +
-                              '&fullScreen=true');
+        expect(urlProps.selectedComponent).to.equal('FirstComponent');
+        expect(urlProps.selectedFixture).to.equal('simple-state');
+        expect(urlProps.fullScreen).to.equal(true);
       });
 
-      it('should generate url for opening fixture editor', function() {
+      it('should include component and fixture in fixture editor url',
+         function() {
         render();
 
-        var href = $(component.refs.fixtureEditorButton.getDOMNode())
-                   .attr('href');
+        var element = component.refs.fixtureEditorButton.getDOMNode(),
+            urlProps = getUrlProps(element);
 
-        expect(href).to.equal('?fixturePath=SecondComponent%2Fsimple-state' +
-                              '&fixtureEditor=true');
+        expect(urlProps.selectedComponent).to.equal('FirstComponent');
+        expect(urlProps.selectedFixture).to.equal('simple-state');
+        expect(urlProps.fixtureEditor).to.equal(true);
+      });
+    });
+
+    describe('with fixture editor open', function() {
+      beforeEach(function() {
+        props.fixtureEditor = true;
       });
 
-      describe('with fixture editor open', function() {
-        beforeEach(function() {
-          props.fixtureEditor = true;
-        });
+      it('should render fixture editor', function() {
+        render();
 
-        it('should render fixture editor', function() {
-          render();
-
-          expect(component.refs.fixtureEditor).to.exist;
-        });
-
-        it('should add class on preview container', function() {
-          render();
-
-          expect($(component.refs.previewContainer.getDOMNode())
-                 .hasClass('aside-fixture-editor')).to.be.true;
-        });
-
-        it('should populate fixture editor textarea from state', function() {
-          render({
-            state: {
-              fixtureUserInput: 'lorem ipsum'
-            }
-          });
-
-          expect(component.refs.fixtureEditor.getDOMNode().value)
-                 .to.equal(component.state.fixtureUserInput);
-        });
-
-        it('should generate url with fixture path and fixture editor',
-          function() {
-          render();
-
-          var firstHref = $component.find('.component-fixture a').attr('href');
-
-          expect(firstHref).to.equal(
-              '?fixturePath=FirstComponent%2Fblank-state&fixtureEditor=true');
-        });
-
-        it('should generate selected fixture editor button', function() {
-          render();
-
-          expect($(component.getDOMNode())
-                 .find('.fixture-editor-button')
-                 .hasClass('selected-button')).to.be.true;
-        });
-
-        it('should generate url for closing fixture editor', function() {
-          render();
-
-          var href = $(component.refs.fixtureEditorButton.getDOMNode())
-                     .attr('href');
-
-          expect(href).to.equal('?fixturePath=SecondComponent%2Fsimple-state' +
-                                '&fixtureEditor=false');
-        });
-
-        it('should add invalid class on fixture editor on state flag',
-           function() {
-          render({
-            state: {
-              isFixtureUserInputValid: false
-            }
-          });
-
-          expect($(component.refs.fixtureEditor.getDOMNode())
-                 .hasClass('invalid-syntax')).to.be.true;
-        });
+        expect(component.refs.fixtureEditor).to.exist;
       });
+
+      it('should add class on preview container', function() {
+        render();
+
+        expect($(component.refs.previewContainer.getDOMNode())
+               .hasClass('aside-fixture-editor')).to.be.true;
+      });
+
+      it('should populate fixture editor textarea from state', function() {
+        render({
+          state: {
+            fixtureUserInput: 'lorem ipsum'
+          }
+        });
+
+        expect(component.refs.fixtureEditor.getDOMNode().value)
+               .to.equal(component.state.fixtureUserInput);
+      });
+
+      it('should generate selected fixture editor button', function() {
+        render();
+
+        expect($(component.getDOMNode())
+               .find('.fixture-editor-button')
+               .hasClass('selected-button')).to.be.true;
+      });
+
+      it('should generate url for closing fixture editor', function() {
+        render();
+
+        var element = component.refs.fixtureEditorButton.getDOMNode(),
+            urlProps = getUrlProps(element);
+
+        expect(urlProps.fixtureEditor).to.equal(false);
+      });
+
+      it('should include fixtor editor in fixture url', function() {
+        var firstFixtureLink = $component.find('.component-fixture a'),
+            urlProps = getUrlProps(firstFixtureLink);
+
+        expect(urlProps.selectedComponent).to.equal('FirstComponent');
+        expect(urlProps.selectedFixture).to.equal('blank-state');
+        expect(urlProps.fixtureEditor).to.equal(true);
+      });
+
+      it('should add invalid class on fixture editor on state flag',
+         function() {
+        render({
+          state: {
+            isFixtureUserInputValid: false
+          }
+        });
+
+        expect($(component.refs.fixtureEditor.getDOMNode())
+               .hasClass('invalid-syntax')).to.be.true;
+      });
+    });
+
+    it('should generate url for closing editor with fixture', function() {
+      render({
+        selectedComponent: 'FirstComponent',
+        selectedFixture: 'simple-state',
+        fixtureEditor: true
+      });
+
+      var element = component.refs.fixtureEditorButton.getDOMNode(),
+          urlProps = getUrlProps(element);
+
+      expect(urlProps.selectedComponent).to.equal('FirstComponent');
+      expect(urlProps.selectedFixture).to.equal('simple-state');
+      expect(urlProps.fixtureEditor).to.equal(false);
     });
   });
 });

--- a/tests/components/component-playground/state.js
+++ b/tests/components/component-playground/state.js
@@ -9,8 +9,8 @@ describe('ComponentPlayground component', function() {
       $component,
       props;
 
-  // Alow tests to extend fixture before rendering
   function render(extraProps) {
+    // Alow tests to extend fixture before rendering
     _.merge(props, extraProps);
 
     component = renderComponent(ComponentPlayground, props);
@@ -21,7 +21,6 @@ describe('ComponentPlayground component', function() {
     // Don't render any children
     sinon.stub(Cosmos, 'createElement');
 
-    // Allow tests to extend the base fixture
     props = {
       fixtures: {
         FirstComponent: {
@@ -49,80 +48,75 @@ describe('ComponentPlayground component', function() {
       expect(component.state.expandedComponents.length).to.equal(0);
     });
 
-    it('should expand component from selected fixture', function() {
-      render({
-        fixturePath: 'SecondComponent/simple-state'
-      });
-
-      expect(component.state.expandedComponents.length).to.equal(1);
-      expect(component.state.expandedComponents[0]).to.equal('SecondComponent');
-    });
-
-    it('should populate state with fixture contents', function() {
-      render({
-        fixturePath: 'SecondComponent/simple-state'
-      });
-
-      expect(component.state.fixtureContents.myProp).to.equal(true);
-    });
-
-    it('should populate user input with stringified fixture contents',
-       function() {
-      render({
-        fixturePath: 'SecondComponent/simple-state'
-      });
-
-      var fixtureContents = component.state.fixtureContents;
-      expect(component.state.fixtureUserInput)
-            .to.equal(JSON.stringify(fixtureContents, null, 2));
-    });
-
-    describe('on fixture transition', function() {
-      it('should reset expanded components', function() {
-        render({
-          fixturePath: 'SecondComponent/simple-state'
+    describe('with fixture selected', function() {
+      beforeEach(function() {
+        _.extend(props, {
+          selectedComponent: 'FirstComponent',
+          selectedFixture: 'blank-state'
         });
-
-        component.setProps({fixturePath: 'FirstComponent/blank-state'});
-
-        expect(component.state.expandedComponents.length).to.equal(1);
-        expect(component.state.expandedComponents[0])
-              .to.equal('FirstComponent');
       });
 
-      it('should reset fixture contents', function() {
-        render({
-          fixturePath: 'SecondComponent/simple-state'
-        });
+      it('should expand component from selected fixture', function() {
+        render();
 
-        component.setProps({fixturePath: 'FirstComponent/blank-state'});
+        var expandedComponents = component.state.expandedComponents;
+
+        expect(expandedComponents.length).to.equal(1);
+        expect(expandedComponents[0]).to.equal('FirstComponent');
+      });
+
+      it('should populate state with fixture contents', function() {
+        render();
 
         expect(component.state.fixtureContents.myProp).to.equal(false);
       });
 
-      it('should reset fixture user input', function() {
-        render({
-          fixturePath: 'SecondComponent/simple-state'
-        });
+      it('should populate user input with stringified fixture contents',
+         function() {
+        render();
 
-        component.setProps({fixturePath: 'FirstComponent/blank-state'});
+        var fixtureContents = component.state.fixtureContents;
 
-        var fixtureContents = props.fixtures.FirstComponent['blank-state'];
         expect(component.state.fixtureUserInput)
               .to.equal(JSON.stringify(fixtureContents, null, 2));
       });
 
-      it('should reset valid user input flag', function() {
-        render({
-          fixturePath: 'SecondComponent/simple-state',
-          state: {
-            isFixtureUserInputValid: false
-          }
+      describe('on fixture transition', function() {
+        beforeEach(function() {
+          render({
+            state: {
+              isFixtureUserInputValid: false
+            }
+          });
+
+          component.setProps({
+            selectedComponent: 'SecondComponent',
+            selectedFixture: 'simple-state'
+          });
         });
 
-        component.setProps({fixturePath: 'FirstComponent/blank-state'});
+        it('should expand both prev and new components', function() {
+          var expandedComponents = component.state.expandedComponents;
 
-        expect(component.state.isFixtureUserInputValid).to.be.true;
+          expect(expandedComponents.length).to.equal(2);
+          expect(expandedComponents[0]).to.equal('FirstComponent');
+          expect(expandedComponents[1]).to.equal('SecondComponent');
+        });
+
+        it('should reset fixture contents', function() {
+          expect(component.state.fixtureContents.myProp).to.equal(true);
+        });
+
+        it('should reset fixture user input', function() {
+          var fixtureContents = props.fixtures.FirstComponent['blank-state'];
+
+          expect(JSON.parse(component.state.fixtureUserInput).myProp)
+                .to.equal(true);
+        });
+
+        it('should reset valid user input flag', function() {
+          expect(component.state.isFixtureUserInputValid).to.be.true;
+        });
       });
     });
   });


### PR DESCRIPTION
Allows components or fixtures to contain slashes in their name.

- [x] Don't reset expanded components when changing fixture
- [x] Allow rendering a fixture in place (no fixture selected)
  - [x] Display component inside the fixture editor