### PR TITLE
Extend fixture editor input from selected fixture content

### DIFF
--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -41,7 +41,7 @@ module.exports = React.createClass({
 
     getFixtureContents: function(props) {
       if (!this.isFixtureSelected(props)) {
-        return null;
+        return {};
       }
 
       var fixture = props.fixtures[props.selectedComponent]
@@ -54,7 +54,7 @@ module.exports = React.createClass({
 
     getFixtureUserInput: function(props) {
       if (!this.isFixtureSelected(props)) {
-        return '';
+        return '{}';
       }
 
       return JSON.stringify(this.getFixtureContents(props), null, 2);
@@ -117,7 +117,8 @@ module.exports = React.createClass({
                onClick={this.routeLink}>
               <span className="react">React</span> Component Playground
             </a>
-            {!this.state.fixtureContents ? this._renderCosmosPlug() : null}
+            {_.isEmpty(this.state.fixtureContents) ? this._renderCosmosPlug()
+                                                   : null}
           </h1>
         </div>
         <div className="fixtures">
@@ -187,7 +188,8 @@ module.exports = React.createClass({
   _renderContentFrame: function() {
     return <div className="content-frame">
       <div ref="previewContainer" className={this._getPreviewClasses()}>
-        {this.state.fixtureContents ? this.loadChild('preview') : null}
+        {!_.isEmpty(this.state.fixtureContents) ? this.loadChild('preview')
+                                                : null}
       </div>
       {this.props.fixtureEditor ? this._renderFixtureEditor() : null}
     </div>
@@ -285,7 +287,7 @@ module.exports = React.createClass({
         newState = {fixtureUserInput: userInput};
 
     try {
-      newState.fixtureContents = userInput ? JSON.parse(userInput) : null;
+      newState.fixtureContents = userInput ? JSON.parse(userInput) : {};
       newState.isFixtureUserInputValid = true;
     } catch (e) {
       newState.isFixtureUserInputValid = false;

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -287,7 +287,14 @@ module.exports = React.createClass({
         newState = {fixtureUserInput: userInput};
 
     try {
-      newState.fixtureContents = userInput ? JSON.parse(userInput) : {};
+      var fixtureContents =
+        this.constructor.getSelectedFixtureContents(this.props);
+
+      if (userInput) {
+        _.merge(fixtureContents, JSON.parse(userInput));
+      }
+
+      newState.fixtureContents = fixtureContents;
       newState.isFixtureUserInputValid = true;
     } catch (e) {
       newState.isFixtureUserInputValid = false;

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -39,7 +39,7 @@ module.exports = React.createClass({
       return props.selectedComponent && props.selectedFixture;
     },
 
-    getFixtureContents: function(props) {
+    getSelectedFixtureContents: function(props) {
       if (!this.isFixtureSelected(props)) {
         return {};
       }
@@ -52,20 +52,20 @@ module.exports = React.createClass({
       }, fixture);
     },
 
-    getFixtureUserInput: function(props) {
+    getSelectedFixtureUserInput: function(props) {
       if (!this.isFixtureSelected(props)) {
         return '{}';
       }
 
-      return JSON.stringify(this.getFixtureContents(props), null, 2);
+      return JSON.stringify(this.getSelectedFixtureContents(props), null, 2);
     },
 
     getFixtureState: function(props, expandedComponents) {
       return {
         expandedComponents: this.getExpandedComponents(props,
                                                        expandedComponents),
-        fixtureContents: this.getFixtureContents(props),
-        fixtureUserInput: this.getFixtureUserInput(props),
+        fixtureContents: this.getSelectedFixtureContents(props),
+        fixtureUserInput: this.getSelectedFixtureUserInput(props),
         isFixtureUserInputValid: true
       };
     }

--- a/components/component-playground.jsx
+++ b/components/component-playground.jsx
@@ -47,7 +47,7 @@ module.exports = React.createClass({
       var fixture = props.fixtures[props.selectedComponent]
                                   [props.selectedFixture];
 
-      return _.extend({
+      return _.merge({
         component: props.selectedComponent
       }, fixture);
     },

--- a/tests/components/component-playground/events.js
+++ b/tests/components/component-playground/events.js
@@ -128,7 +128,7 @@ describe('ComponentPlayground component', function() {
       it('should empty fixture contents on empty input', function() {
         triggerChange('');
 
-        expect(component.state.fixtureContents).to.equal(null);
+        expect(component.state.fixtureContents).to.deep.equal({});
       });
 
       it('should call console.error on invalid change', function() {

--- a/tests/components/component-playground/events.js
+++ b/tests/components/component-playground/events.js
@@ -151,19 +151,26 @@ describe('ComponentPlayground component', function() {
     });
 
     describe("editing fixture with selected fixture", function() {
-      beforeEach(function() {
-        render({
-          fixtures: {
-            MyComponent: {
-              'simple state': {
-                defaultProp: true
-              }
+      var fixtures = {
+        MyComponent: {
+          'simple state': {
+            defaultProp: true,
+            nested: {
+              nestedProp: true
             }
-          },
+          }
+        }
+      };
+
+      beforeEach(function() {
+        _.extend(props, {
+          fixtures: fixtures,
           selectedComponent: 'MyComponent',
           selectedFixture: 'simple state',
           fixtureEditor: true
         });
+
+        render();
       });
 
       it('should extend fixture contents with user input', function() {
@@ -171,6 +178,13 @@ describe('ComponentPlayground component', function() {
 
         expect(component.state.fixtureContents.customProp).to.equal(true);
         expect(component.state.fixtureContents.defaultProp).to.equal(true);
+      });
+
+      it('should not alter the original fixture contents', function() {
+        triggerChange('{"nested": {"nestedProp": false}}');
+
+        expect(fixtures.MyComponent['simple state'].nested.nestedProp)
+              .to.be.true;
       });
     });
   });

--- a/tests/components/component-playground/events.js
+++ b/tests/components/component-playground/events.js
@@ -19,6 +19,11 @@ describe('ComponentPlayground component', function() {
     $component = $(component.getDOMNode());
   };
 
+  var triggerChange = function(value) {
+    utils.Simulate.change(component.refs.fixtureEditor.getDOMNode(),
+                          {target: {value: value}});
+  };
+
   beforeEach(function() {
     sinon.stub(console, 'error');
 
@@ -88,11 +93,6 @@ describe('ComponentPlayground component', function() {
     });
 
     describe('editing fixture', function() {
-      var triggerChange = function(value) {
-        utils.Simulate.change(component.refs.fixtureEditor.getDOMNode(),
-                              {target: {value: value}});
-      };
-
       var initialFixtureContents = {
         myProp: 'dolor sit'
       };
@@ -147,6 +147,30 @@ describe('ComponentPlayground component', function() {
         triggerChange('lorem ipsum');
 
         expect(component.state.isFixtureUserInputValid).to.equal(false);
+      });
+    });
+
+    describe("editing fixture with selected fixture", function() {
+      beforeEach(function() {
+        render({
+          fixtures: {
+            MyComponent: {
+              'simple state': {
+                defaultProp: true
+              }
+            }
+          },
+          selectedComponent: 'MyComponent',
+          selectedFixture: 'simple state',
+          fixtureEditor: true
+        });
+      });
+
+      it('should extend fixture contents with user input', function() {
+        triggerChange('{"customProp": true}');
+
+        expect(component.state.fixtureContents.customProp).to.equal(true);
+        expect(component.state.fixtureContents.defaultProp).to.equal(true);
       });
     });
   });

--- a/tests/components/component-playground/render.js
+++ b/tests/components/component-playground/render.js
@@ -57,7 +57,9 @@ describe('ComponentPlayground component', function() {
     it('should not render cosmos plug with preview loaded', function() {
       render({
         state: {
-          fixtureContents: {}
+          fixtureContents: {
+            myProp: true
+          }
         }
       });
 


### PR DESCRIPTION
- [x] Default state.fixtureContent to `{}` instead of `null`
- [x] Use `_.merge(fixtureContent, fixtureUserInput)` on editor change event