### PR TITLE
Add hot reloading for React components

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ specified via cli args:
 node_modules/.bin/component-playground --components-path src/components --fixtures-path tests/fixtures
 ```
 
+Finally, Cosmos includes [React Hot Loader](http://gaearon.github.io/react-hot-loader/) and has webpack's [hot module replacement](http://webpack.github.io/docs/hot-module-replacement.html) enabled so you can tweak the components and their styles without refreshing the browser:
+
+![React Hot Loader in Cosmos](https://cloud.githubusercontent.com/assets/250750/7522175/2e839f04-f4fc-11e4-890c-e60505c50f57.gif)
+
 ### Thank you for your interest!
 
 [![Join the chat at https://gitter.im/skidding/cosmos](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/skidding/cosmos?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/bin/component-playground.js
+++ b/bin/component-playground.js
@@ -12,6 +12,7 @@ var compiler = webpack(require(path.join(playgroundPath, 'webpack.config.js')));
 var server = new WebpackDevServer(compiler, {
   contentBase: path.join(playgroundPath, 'public'),
   publicPath: '/build/',
+  hot: true
 });
 
 server.listen(8989, 'localhost', function() {});

--- a/component-playground/webpack.config.js
+++ b/component-playground/webpack.config.js
@@ -1,5 +1,6 @@
 var path = require('path'),
-    argv = require('yargs').argv;
+    argv = require('yargs').argv,
+    webpack = require('webpack');
 
 var playgroundPath = __dirname,
     rootPath = path.join(playgroundPath, '..'),
@@ -11,7 +12,12 @@ var resolvePath = function(userPath) {
 };
 
 module.exports = {
-  entry: path.join(playgroundPath, 'entry.js'),
+  context: playgroundPath,
+  entry: [
+    'webpack-dev-server/client?http://localhost:8989',
+    'webpack/hot/dev-server',
+    './entry'
+  ],
   resolve: {
     alias: {
       components: resolvePath(argv.componentsPath || 'components'),
@@ -26,7 +32,7 @@ module.exports = {
     loaders: [{
       test: /\.jsx?$/,
       exclude: /node_modules/,
-      loader: 'jsx-loader?harmony'
+      loaders: ['react-hot-loader', 'jsx-loader?harmony']
     }, {
       test: /\.css$/,
       loader: 'style-loader!css-loader'
@@ -39,6 +45,11 @@ module.exports = {
     libraryTarget: 'umd',
     library: 'cosmosRouter',
     path: path.join(playgroundPath, 'public', 'build'),
-    filename: 'bundle.js'
-  }
+    filename: 'bundle.js',
+    publicPath: '/build/'
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosmos-js",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A foundation for maintainable web applications",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "less-loader": "^2.2.0",
     "lodash": "^3.5.0",
     "react-component-playground": "^0.2.3",
+    "react-hot-loader": "^1.2.7",
     "react-querystring-router": "^0.2.0",
     "style-loader": "^0.9.0",
     "webpack": "^1.7.3",


### PR DESCRIPTION
Fixes #124.
Note that hot reloading only works for React components; changing a fixture will force a full reload.

It may be possible to do hot reloading for fixtures too but to be honest I couldn't find where they were loaded in the source. :-)