### PR TITLE
Use latest JS features in Babel

### DIFF
--- a/component-playground/config.js
+++ b/component-playground/config.js
@@ -53,7 +53,7 @@ config.webpack = {
     loaders: [{
       test: /\.jsx?$/,
       exclude: /node_modules/,
-      loaders: ['react-hot-loader', 'babel-loader']
+      loaders: ['react-hot-loader', 'babel-loader?stage=1']
     }, {
       test: /\.css$/,
       loader: 'style-loader!css-loader'


### PR DESCRIPTION
Since we're so cutting edge, might as well use the `stage=1` features of `babel`. I usually add this on my own version..