### PR TITLE
Added support for url-loader.

### DIFF
--- a/component-playground/config.js
+++ b/component-playground/config.js
@@ -60,6 +60,9 @@ config.webpack = {
     }, {
       test: /\.less$/,
       loader: 'style-loader!css-loader!less-loader'
+    }, {
+      test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+      loader: 'url-loader?limit=100000'
     }]
   },
   output: {


### PR DESCRIPTION
This adds support for loading external assets, eg. for when requiring external stylesheets using images or fonts (think bootstrap for example).

Credit: https://github.com/webpack/css-loader/issues/38#issuecomment-72287584