### PR TITLE
terminate regex for fixture files

### DIFF
--- a/src/get-component-fixture-tree.js
+++ b/src/get-component-fixture-tree.js
@@ -51,7 +51,7 @@ module.exports = function() {
 
 var getFixturesForComponent = function(componentName) {
   var requireFixture = require.context('COSMOS_FIXTURES', true),
-      isFixtureOfComponent = new RegExp('./' + componentName + '/([^/]+).js'),
+      isFixtureOfComponent = new RegExp('./' + componentName + '/([^/]+).js$'),
       fixtures = {};
 
   requireFixture.keys().forEach(function(fixturePath) {


### PR DESCRIPTION
Fix the regex for fixture files so it only matches `*.js` files, not `*.js*` files. This was causing bugs for me because it was picking up my editor's backup files (e.g. `foo.js~`).