### PR TITLE
account for es6 default classes (compiled with Babel)

### DIFF
--- a/src/get-component-fixture-tree.js
+++ b/src/get-component-fixture-tree.js
@@ -22,6 +22,10 @@
   *   }
   * }
   */
+ 
+var normalizeModule = function (module) {
+    return (module.default) ? module.default : module;
+};
 module.exports = function() {
   var requireComponent = require.context('COSMOS_COMPONENTS', true),
       isComponent = /^\.\/(.+)\.jsx?$/,
@@ -36,7 +40,7 @@ module.exports = function() {
     // Fixtures are grouped per component
     var componentName = match[1];
     components[componentName] = {
-      class: requireComponent(componentPath).default ? requireComponent(componentPath).default: requireComponent(componentPath),
+      class: normalizeModule(requireComponent(componentPath)),
       fixtures: getFixturesForComponent(componentName)
     };
 
@@ -57,7 +61,7 @@ var getFixturesForComponent = function(componentName) {
   requireFixture.keys().forEach(function(fixturePath) {
     var match = fixturePath.match(isFixtureOfComponent);
     if (match) {
-      fixtures[match[1]] = requireFixture(fixturePath);
+      fixtures[match[1]] = normalizeModule(requireFixture(fixturePath));
     }
   });
 

--- a/src/get-component-fixture-tree.js
+++ b/src/get-component-fixture-tree.js
@@ -36,7 +36,7 @@ module.exports = function() {
     // Fixtures are grouped per component
     var componentName = match[1];
     components[componentName] = {
-      class: requireComponent(componentPath),
+      class: requireComponent(componentPath).default ? requireComponent(componentPath).default: requireComponent(componentPath),
       fixtures: getFixturesForComponent(componentName)
     };
 


### PR DESCRIPTION
I was having troubling getting the following component to render within the playground:

```
import React from 'react';

export default function PP() {
    return (
        <h1>
            HI
        </h1>
    );
}
```
Turned out the reason was because this exports as `{ default : function }` instead of just `function`. 

Hand-tested with other non-es6 commonjs exports and it seems fine, happy to write other test-cases if needed.