### PR TITLE
Fix ES6 modules handling

### DIFF
--- a/src/get-component-fixture-tree.js
+++ b/src/get-component-fixture-tree.js
@@ -37,7 +37,7 @@ module.exports = function() {
     var componentName = match[1];
     var component = requireComponent(componentPath)
 
-    if (component.__esmodule) {
+    if (component.__esModule) {
       component = component[componentName] || component.default
     }
 

--- a/src/get-component-fixture-tree.js
+++ b/src/get-component-fixture-tree.js
@@ -35,12 +35,12 @@ module.exports = function() {
 
     // Fixtures are grouped per component
     var componentName = match[1];
-    var component = requireComponent(componentPath)
+    var component = requireComponent(componentPath);
 
     if (component.__esModule) {
-      var parts = componentName.split('/')
-      var name = parts[parts.length - 1]
-      component = component[name] || component.default
+      var parts = componentName.split('/');
+      var name = parts[parts.length - 1];
+      component = component[name] || component.default;
     }
 
     if (!component || !isReactClass(component)) {
@@ -63,7 +63,7 @@ module.exports = function() {
 };
 
 var isReactClass = function(component) {
-  return typeof component === 'string' || typeof component === 'function'
+  return typeof component === 'string' || typeof component === 'function';
 }
 
 var getFixturesForComponent = function(componentName) {

--- a/src/get-component-fixture-tree.js
+++ b/src/get-component-fixture-tree.js
@@ -37,6 +37,9 @@ module.exports = function() {
     var componentName = match[1];
     var component = requireComponent(componentPath);
 
+    // This is an implementation detail of Babel:
+    // https://medium.com/@kentcdodds/misunderstanding-es6-modules-upgrading-babel-tears-and-a-solution-ad2d5ab93ce0#.skvldbg39
+    // It looks like to be a "standard": https://github.com/esnext/es6-module-transpiler/issues/86 **for now**.
     if (component.__esModule) {
       var parts = componentName.split('/');
       var name = parts[parts.length - 1];

--- a/src/get-component-fixture-tree.js
+++ b/src/get-component-fixture-tree.js
@@ -35,8 +35,19 @@ module.exports = function() {
 
     // Fixtures are grouped per component
     var componentName = match[1];
+    var component = requireComponent(componentPath)
+
+    if (component.__esmodule) {
+      component = component[componentName] || component.default
+    }
+
+    if (!component || !isReactClass(component)) {
+      // Invalid Component provided.
+      return;
+    }
+
     components[componentName] = {
-      class: requireComponent(componentPath),
+      class: component,
       fixtures: getFixturesForComponent(componentName)
     };
 
@@ -48,6 +59,10 @@ module.exports = function() {
 
   return components;
 };
+
+var isReactClass = function(component) {
+  return typeof component === 'string' || typeof component === 'function'
+}
 
 var getFixturesForComponent = function(componentName) {
   var requireFixture = require.context('COSMOS_FIXTURES', true),

--- a/src/get-component-fixture-tree.js
+++ b/src/get-component-fixture-tree.js
@@ -38,7 +38,9 @@ module.exports = function() {
     var component = requireComponent(componentPath)
 
     if (component.__esModule) {
-      component = component[componentName] || component.default
+      var parts = componentName.split('/')
+      var name = parts[parts.length - 1]
+      component = component[name] || component.default
     }
 
     if (!component || !isReactClass(component)) {


### PR DESCRIPTION
Hi there,

As discussed in #183, here is my fix for the ES6 modules.

So, let me walk through the changes:

## How to detect if we have an ES6 module?

Thankfully, it seems like Babel 6 adds a constant: `__esModule` and set it to `true` if it is an ES6 Module.

So that:

* If we have an `Object`.
* It has a `__esModule` property which is equal to `true`

We have an ES6 module.

*Drawback*: What about others transpilers? Should we rely on an "implementation detail"? I would love to know the advice of a Babel developer here if possible.

## What do we do once we know it's an ES6 module

There are two types of export in ES6:

* Named exports: `export const A_CONSTANT = 3`
* Default exports: `export default MyComponentClass`

Based on this, it gives us two properties on the module object:

* `default`
* `A_CONSTANT` (named exports)

So alright, we can just say: "take what is available" (either default or named export).

### Problem: Which order? Do we prefer default exports to named exports?

I would argue that named exports first *THEN* default export is better when you have components, but that could be my own standard.

The thing is that most of the time you have:

```js
export class MyComponent extends Component {
...
}

export default someDecorator(MyComponent)
```

The `someDecorator` may be something like `connect` (from `react-redux`) or `reduxForm` (from `redux-form`) and those depends on the `context`.

But we don't pass meaningful `context` (like in the real app).

So the simplest way to test them is to use the named export rather than the default one.

**Drawback**: One could argue that testing decorated components are not the goal of the playground.
I believe that it would be awesome to take a step to support decorated components which works like a dumb one.

## Why do we include invalid components?
A cool thing added is that: even if you have invalid components (read: not `React.createClass` or `React.DOM` or `React.Component` stuff), Cosmos won't include them and ignore.

If we don't do that, when we render them, it seems like that an error is thrown and it's kind of impossible to know why or how it happens.

---

### Suggestions

In my opinion, it makes `DX++`, we could add beautiful alerts like "hey! there are strange components in your tree, pay attention to what you write!" if we detect invalid components.
Or if all components are invalid, we can just alert the developer of: "Something is wrong with your architecture, look your components, do you export them? Is your Webpack config alright?"

That's it.
If there are code style concerns, let me know and I'll do the changes.

Thanks again for this cool project :tada: !